### PR TITLE
Add password gate for admin and event access

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -5,9 +5,12 @@ import useLocalStorage from './hooks/useLocalStorage';
 import CreateEvent from './components/CreateEvent';
 import EditEvent from './components/EditEvent';
 import ProtectedEventView from './components/ProtectedEventView';
+import AccessGate from './components/AccessGate';
+import ProtectedAdminRoute, { setAdminAuthorized } from './components/ProtectedAdminRoute';
 
 const App: React.FC = () => {
   const [events, setEvents] = useLocalStorage<Event[]>('party-events', []);
+  const adminPassword = import.meta.env.VITE_ADMIN_PASSWORD || 'admin123';
 
   const addEvent = (event: Event) => {
     setEvents(prevEvents => [...prevEvents, event]);
@@ -54,7 +57,24 @@ const App: React.FC = () => {
         </header>
         <main className="flex-grow">
           <Routes>
-            <Route path="/" element={<CreateEvent events={events} addEvent={addEvent} deleteEvent={deleteEvent} />} />
+            <Route
+              path="/"
+              element={
+                <AccessGate
+                  events={events}
+                  adminPassword={adminPassword}
+                  onAdminAuthorized={setAdminAuthorized}
+                />
+              }
+            />
+            <Route
+              path="/create"
+              element={
+                <ProtectedAdminRoute>
+                  <CreateEvent events={events} addEvent={addEvent} deleteEvent={deleteEvent} />
+                </ProtectedAdminRoute>
+              }
+            />
             <Route path="/event/:eventId" element={<ProtectedEventView events={events} addRsvp={addRsvp} />} />
             <Route path="/event/:eventId/edit" element={<EditEvent events={events} editEvent={editEvent} />} />
           </Routes>

--- a/README.md
+++ b/README.md
@@ -15,8 +15,9 @@ View your app in AI Studio: https://ai.studio/apps/drive/19mi9HO88ttJri_mR9qvzq2
 
 1. Install dependencies:
    `npm install`
-2. Set the `GEMINI_API_KEY` in [.env.local](.env.local) to your Gemini API key
-3. Run the app:
+2. (Optional) Set the admin password by defining `VITE_ADMIN_PASSWORD` in [.env.local](.env.local). The default value is `admin123`.
+3. Set the `GEMINI_API_KEY` in [.env.local](.env.local) to your Gemini API key
+4. Run the app:
    `npm run dev`
 
 ## Run with Docker

--- a/components/AccessGate.tsx
+++ b/components/AccessGate.tsx
@@ -1,0 +1,81 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import type { Event } from '../types';
+import { LockClosedIcon } from './icons';
+
+interface AccessGateProps {
+  events: Event[];
+  adminPassword: string;
+  onAdminAuthorized: () => void;
+}
+
+const AccessGate: React.FC<AccessGateProps> = ({ events, adminPassword, onAdminAuthorized }) => {
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+  const navigate = useNavigate();
+
+  const handleSubmit = (event: React.FormEvent) => {
+    event.preventDefault();
+
+    const trimmedPassword = password.trim();
+    if (!trimmedPassword) {
+      setError('Please enter a password.');
+      return;
+    }
+
+    if (trimmedPassword === adminPassword) {
+      setError('');
+      onAdminAuthorized();
+      navigate('/create');
+      return;
+    }
+
+    const matchingEvent = events.find(evt => evt.password && evt.password === trimmedPassword);
+    if (matchingEvent) {
+      setError('');
+      navigate(`/event/${matchingEvent.id}`);
+      return;
+    }
+
+    setError('No event or admin area matched that password. Please try again.');
+    setPassword('');
+  };
+
+  return (
+    <div className="max-w-md mx-auto p-4 sm:p-6 lg:p-8 mt-16">
+      <div className="bg-white rounded-2xl shadow-2xl shadow-slate-200 p-8 text-center">
+        <LockClosedIcon className="h-12 w-12 text-primary mx-auto mb-4" />
+        <h1 className="text-2xl font-bold text-slate-800">Welcome!</h1>
+        <p className="mt-2 text-slate-600">
+          Enter the event password to view an invitation or use the admin password to manage events.
+        </p>
+
+        <form onSubmit={handleSubmit} className="mt-6 space-y-4">
+          <div className="space-y-2">
+            <label htmlFor="access-password" className="sr-only">
+              Password
+            </label>
+            <input
+              id="access-password"
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              placeholder="Enter password"
+              autoFocus
+              className="w-full px-4 py-2 border border-slate-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary transition"
+            />
+          </div>
+          {error && <p className="text-sm text-red-600">{error}</p>}
+          <button
+            type="submit"
+            className="w-full bg-primary text-white font-bold py-3 px-4 rounded-lg hover:bg-primary-700 focus:outline-none focus:ring-4 focus:ring-primary-300 transition-all duration-300"
+          >
+            Continue
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default AccessGate;

--- a/components/ProtectedAdminRoute.tsx
+++ b/components/ProtectedAdminRoute.tsx
@@ -1,0 +1,47 @@
+import React, { useMemo } from 'react';
+import { Navigate } from 'react-router-dom';
+
+interface ProtectedAdminRouteProps {
+  children: React.ReactElement;
+}
+
+const ADMIN_SESSION_KEY = 'admin-auth';
+
+const ProtectedAdminRoute: React.FC<ProtectedAdminRouteProps> = ({ children }) => {
+  const isAuthorized = useMemo(() => {
+    try {
+      return typeof window !== 'undefined' && window.sessionStorage.getItem(ADMIN_SESSION_KEY) === 'true';
+    } catch (error) {
+      console.error('Unable to read admin session state:', error);
+      return false;
+    }
+  }, []);
+
+  if (!isAuthorized) {
+    return <Navigate to="/" replace />;
+  }
+
+  return children;
+};
+
+export const setAdminAuthorized = () => {
+  try {
+    if (typeof window !== 'undefined') {
+      window.sessionStorage.setItem(ADMIN_SESSION_KEY, 'true');
+    }
+  } catch (error) {
+    console.error('Unable to persist admin session state:', error);
+  }
+};
+
+export const clearAdminAuthorization = () => {
+  try {
+    if (typeof window !== 'undefined') {
+      window.sessionStorage.removeItem(ADMIN_SESSION_KEY);
+    }
+  } catch (error) {
+    console.error('Unable to clear admin session state:', error);
+  }
+};
+
+export default ProtectedAdminRoute;


### PR DESCRIPTION
## Summary
- add an access gate that routes based on admin or event passwords
- protect the event creation route behind an admin session
- document the optional VITE_ADMIN_PASSWORD configuration

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cda97c4bc8832d8bd1fce21625b7f4