### PR TITLE
Restrict guest access and enhance admin insights

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,9 @@ View your app in AI Studio: https://ai.studio/apps/drive/19mi9HO88ttJri_mR9qvzq2
 
 1. Install dependencies:
    `npm install`
-2. Set the `GEMINI_API_KEY` in [.env.local](.env.local) to your Gemini API key
-3. Run the app:
+2. (Optional) Set the admin password by defining `VITE_ADMIN_PASSWORD` in [.env.local](.env.local). The default value is `admin123`.
+3. Set the `GEMINI_API_KEY` in [.env.local](.env.local) to your Gemini API key
+4. Run the app:
    `npm run dev`
 
 ## Run with Docker

--- a/components/AccessGate.tsx
+++ b/components/AccessGate.tsx
@@ -1,0 +1,88 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import type { Event } from '../types';
+import { LockClosedIcon } from './icons';
+
+interface AccessGateProps {
+  events: Event[];
+  adminPassword: string;
+  onAdminAuthorized: () => void;
+}
+
+const AccessGate: React.FC<AccessGateProps> = ({ events, adminPassword, onAdminAuthorized }) => {
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+  const navigate = useNavigate();
+
+  const handleSubmit = (event: React.FormEvent) => {
+    event.preventDefault();
+
+    const trimmedPassword = password.trim();
+    if (!trimmedPassword) {
+      setError('Please enter a password.');
+      return;
+    }
+
+    if (trimmedPassword === adminPassword) {
+      setError('');
+      onAdminAuthorized();
+      navigate('/admin');
+      return;
+    }
+
+    const matchingEvent = events.find(evt => evt.password && evt.password === trimmedPassword);
+    if (matchingEvent) {
+      setError('');
+      try {
+        if (typeof window !== 'undefined') {
+          window.sessionStorage.setItem(`event-auth-${matchingEvent.id}`, 'true');
+        }
+      } catch (storageError) {
+        console.error('Unable to persist event session state:', storageError);
+      }
+      navigate(`/event/${matchingEvent.id}`);
+      return;
+    }
+
+    setError('No event or admin area matched that password. Please try again.');
+    setPassword('');
+  };
+
+  return (
+    <div className="max-w-md mx-auto p-4 sm:p-6 lg:p-8 mt-16">
+      <div className="bg-white rounded-2xl shadow-2xl shadow-slate-200 p-8 text-center">
+        <LockClosedIcon className="h-12 w-12 text-primary mx-auto mb-4" />
+        <h1 className="text-2xl font-bold text-slate-800">Welcome!</h1>
+        <p className="mt-2 text-slate-600">
+          Enter the event password to view an invitation or use the admin password to manage events.
+        </p>
+
+        <form onSubmit={handleSubmit} className="mt-6 space-y-4">
+          <div className="space-y-2">
+            <label htmlFor="access-password" className="sr-only">
+              Password
+            </label>
+            <input
+              id="access-password"
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              placeholder="Enter password"
+              autoFocus
+              className="w-full px-4 py-2 border border-slate-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary transition"
+            />
+          </div>
+          {error && <p className="text-sm text-red-600">{error}</p>}
+          <button
+            type="submit"
+            className="w-full bg-primary text-white font-bold py-3 px-4 rounded-lg hover:bg-primary-700 focus:outline-none focus:ring-4 focus:ring-primary-300 transition-all duration-300"
+          >
+            Continue
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default AccessGate;

--- a/components/AdminDashboard.tsx
+++ b/components/AdminDashboard.tsx
@@ -1,0 +1,250 @@
+import React, { useMemo } from 'react';
+import { Link } from 'react-router-dom';
+import type { Event } from '../types';
+import {
+  CalendarIcon,
+  LockClosedIcon,
+  PencilIcon,
+  PlusIcon,
+  ArrowRightIcon,
+  UsersIcon,
+  CheckCircleIcon,
+  XCircleIcon,
+} from './icons';
+
+interface AdminDashboardProps {
+  events: Event[];
+}
+
+const formatDateRange = (event: Event) => {
+  const start = new Date(event.date);
+  if (Number.isNaN(start.getTime())) {
+    return 'Date not set';
+  }
+
+  const end = event.endDate ? new Date(event.endDate) : null;
+  if (!end || Number.isNaN(end.getTime())) {
+    return start.toLocaleString('en-US', { dateStyle: 'medium', timeStyle: 'short' });
+  }
+
+  const sameDay = start.toDateString() === end.toDateString();
+  if (sameDay) {
+    return `${start.toLocaleDateString('en-US', { dateStyle: 'medium' })}, ${start.toLocaleTimeString('en-US', {
+      hour: 'numeric',
+      minute: '2-digit',
+    })} - ${end.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' })}`;
+  }
+
+  return `${start.toLocaleString('en-US', { dateStyle: 'medium', timeStyle: 'short' })} → ${end.toLocaleString('en-US', {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  })}`;
+};
+
+const AdminDashboard: React.FC<AdminDashboardProps> = ({ events }) => {
+  const { upcomingEvents, pastEvents } = useMemo(() => {
+    const now = new Date();
+    const upcoming: Event[] = [];
+    const past: Event[] = [];
+
+    events.forEach(event => {
+      const endReference = event.endDate ? new Date(event.endDate) : new Date(event.date);
+      if (!Number.isNaN(endReference.getTime()) && endReference < now) {
+        past.push(event);
+      } else {
+        upcoming.push(event);
+      }
+    });
+
+    upcoming.sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
+    past.sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
+
+    return { upcomingEvents: upcoming, pastEvents: past };
+  }, [events]);
+
+  const recentResponses = useMemo(() => {
+    return events
+      .flatMap(event =>
+        event.guests.map(guest => ({
+          eventId: event.id,
+          eventTitle: event.title,
+          guest,
+          respondedAt: guest.respondedAt ? new Date(guest.respondedAt).getTime() : 0,
+        }))
+      )
+      .sort((a, b) => b.respondedAt - a.respondedAt)
+      .slice(0, 6);
+  }, [events]);
+
+  const renderEventCard = (event: Event) => {
+    const attendingGuests = event.guests.filter(guest => guest.status === 'attending');
+    const totalGuests = attendingGuests.reduce((sum, guest) => sum + 1 + guest.plusOnes, 0);
+    const viewerUrl = `/event/${event.id}`;
+
+    return (
+      <article
+        key={event.id}
+        className="bg-white rounded-2xl shadow-lg shadow-slate-200 p-6 flex flex-col justify-between border border-slate-100"
+      >
+        <div className="space-y-4">
+          <header className="flex flex-col gap-2">
+            <div className="flex items-start justify-between gap-3">
+              <div>
+                <h3 className="text-xl font-semibold text-slate-800 leading-tight">{event.title}</h3>
+                <p className="text-sm text-slate-500">Hosted by {event.host}</p>
+              </div>
+              {event.password && (
+                <span className="inline-flex items-center gap-1 rounded-full bg-slate-100 text-slate-600 px-3 py-1 text-xs font-semibold">
+                  <LockClosedIcon className="h-4 w-4" /> Private
+                </span>
+              )}
+            </div>
+            <div className="flex items-start gap-3 text-sm text-slate-600">
+              <CalendarIcon className="h-5 w-5 text-primary mt-0.5" />
+              <span>{formatDateRange(event)}</span>
+            </div>
+            <div className="flex items-start gap-3 text-sm text-slate-600">
+              <UsersIcon className="h-5 w-5 text-primary mt-0.5" />
+              <span>{totalGuests} attending</span>
+            </div>
+          </header>
+        </div>
+
+        <div className="mt-6 grid grid-cols-1 gap-2 sm:grid-cols-2">
+          <Link
+            to={viewerUrl}
+            className="flex items-center justify-center gap-2 rounded-lg border border-primary text-primary font-semibold py-2 hover:bg-primary/10 transition"
+          >
+            View Event <ArrowRightIcon className="h-4 w-4" />
+          </Link>
+          <Link
+            to={`${viewerUrl}/edit`}
+            className="flex items-center justify-center gap-2 rounded-lg bg-primary text-white font-semibold py-2 hover:bg-primary-700 transition"
+          >
+            <PencilIcon className="h-4 w-4" /> Edit Event
+          </Link>
+        </div>
+      </article>
+    );
+  };
+
+  return (
+    <div className="max-w-6xl mx-auto p-4 sm:p-6 lg:p-8 space-y-12">
+      <section className="bg-white rounded-2xl shadow-2xl shadow-slate-200 p-6 sm:p-8 flex flex-col gap-6">
+        <div className="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4">
+          <div>
+            <h1 className="text-3xl sm:text-4xl font-extrabold text-slate-800">Admin Dashboard</h1>
+            <p className="text-slate-600 mt-2">
+              Manage invitations, review upcoming celebrations, and revisit past events all from one place.
+            </p>
+          </div>
+          <Link
+            to="/create"
+            className="inline-flex items-center justify-center gap-2 rounded-lg bg-primary text-white font-semibold py-3 px-5 hover:bg-primary-700 transition"
+          >
+            <PlusIcon className="h-5 w-5" /> Create a New Event
+          </Link>
+        </div>
+      </section>
+
+      <section>
+        <header className="flex items-center justify-between gap-4 mb-6">
+          <div>
+            <h2 className="text-2xl font-bold text-slate-800">Recent RSVPs & Comments</h2>
+            <p className="text-sm text-slate-500">See the latest responses across all of your events.</p>
+          </div>
+          <span className="text-sm text-slate-500">{recentResponses.length} recent</span>
+        </header>
+        {recentResponses.length > 0 ? (
+          <ul className="grid gap-4 md:grid-cols-2">
+            {recentResponses.map(({ guest, eventTitle, eventId, respondedAt }) => {
+              const respondedAtDate = respondedAt ? new Date(respondedAt) : null;
+              const formattedTimestamp = respondedAtDate
+                ? respondedAtDate.toLocaleString('en-US', { dateStyle: 'medium', timeStyle: 'short' })
+                : 'Time unavailable';
+              const isAttending = guest.status === 'attending';
+
+              return (
+                <li key={`${guest.id}-${eventId}`} className="bg-white rounded-2xl shadow-lg shadow-slate-200 p-5 border border-slate-100">
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="flex items-center gap-3">
+                      {isAttending ? (
+                        <CheckCircleIcon className="h-6 w-6 text-green-500" />
+                      ) : (
+                        <XCircleIcon className="h-6 w-6 text-slate-400" />
+                      )}
+                      <div>
+                        <p className="text-base font-semibold text-slate-800">{guest.name}</p>
+                        <p className="text-sm text-slate-500">Responded for {eventTitle}</p>
+                      </div>
+                    </div>
+                    <span className="text-xs font-medium text-slate-400">{formattedTimestamp}</span>
+                  </div>
+                  <div className="mt-3 flex items-center gap-3 text-sm text-slate-600">
+                    <UsersIcon className="h-4 w-4 text-primary" />
+                    <span>
+                      {isAttending ? 'Attending' : 'Not Attending'}
+                      {guest.plusOnes > 0 && ` • +${guest.plusOnes}`}
+                    </span>
+                  </div>
+                  {guest.comment && (
+                    <p className="mt-3 text-sm italic text-slate-600 bg-slate-50 border border-slate-100 rounded-xl p-3">
+                      “{guest.comment}”
+                    </p>
+                  )}
+                </li>
+              );
+            })}
+          </ul>
+        ) : (
+          <div className="bg-white rounded-2xl shadow-lg shadow-slate-200 p-8 text-center text-slate-500">
+            <p>No RSVPs yet. Once guests respond you'll see them here.</p>
+          </div>
+        )}
+      </section>
+
+      <section>
+        <header className="flex items-center justify-between gap-4 mb-6">
+          <div>
+            <h2 className="text-2xl font-bold text-slate-800">Upcoming Events</h2>
+            <p className="text-sm text-slate-500">Stay ahead of the celebrations headed your way.</p>
+          </div>
+          <span className="text-sm text-slate-500">{upcomingEvents.length} upcoming</span>
+        </header>
+        {upcomingEvents.length > 0 ? (
+          <div className="grid gap-4 md:grid-cols-2">
+            {upcomingEvents.map(event => renderEventCard(event))}
+          </div>
+        ) : (
+          <div className="bg-white rounded-2xl shadow-lg shadow-slate-200 p-8 text-center text-slate-500">
+            <p>No upcoming events yet. Start planning your next gathering!</p>
+            <Link to="/create" className="inline-flex items-center gap-2 text-primary font-semibold mt-4">
+              <PlusIcon className="h-4 w-4" /> Create an event
+            </Link>
+          </div>
+        )}
+      </section>
+
+      <section>
+        <header className="flex items-center justify-between gap-4 mb-6">
+          <div>
+            <h2 className="text-2xl font-bold text-slate-800">Past Events</h2>
+            <p className="text-sm text-slate-500">Look back at the memories you've already made.</p>
+          </div>
+          <span className="text-sm text-slate-500">{pastEvents.length} archived</span>
+        </header>
+        {pastEvents.length > 0 ? (
+          <div className="grid gap-4 md:grid-cols-2">
+            {pastEvents.map(event => renderEventCard(event))}
+          </div>
+        ) : (
+          <div className="bg-white rounded-2xl shadow-lg shadow-slate-200 p-8 text-center text-slate-500">
+            <p>No past events yet. Share some invitations and see them appear here.</p>
+          </div>
+        )}
+      </section>
+    </div>
+  );
+};
+
+export default AdminDashboard;

--- a/components/CreateEvent.tsx
+++ b/components/CreateEvent.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import type { Event } from '../types';
+import { DEFAULT_EVENT_THEME } from '../types';
 import DateTimePicker from './DateTimePicker';
 import EventList from './EventList';
 
@@ -9,6 +10,20 @@ interface CreateEventProps {
   addEvent: (event: Event) => void;
   deleteEvent: (eventId: string) => void;
 }
+
+const readFileAsDataUrl = (file: File) =>
+  new Promise<string>((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      if (typeof reader.result === 'string') {
+        resolve(reader.result);
+      } else {
+        reject(new Error('Could not read file.'));
+      }
+    };
+    reader.onerror = () => reject(new Error('Could not read file.'));
+    reader.readAsDataURL(file);
+  });
 
 const CreateEvent: React.FC<CreateEventProps> = ({ events, addEvent, deleteEvent }) => {
   const [title, setTitle] = useState('');
@@ -19,6 +34,13 @@ const CreateEvent: React.FC<CreateEventProps> = ({ events, addEvent, deleteEvent
   const [message, setMessage] = useState('');
   const [showGuestList, setShowGuestList] = useState(true);
   const [password, setPassword] = useState('');
+  const [allowShareLink, setAllowShareLink] = useState(true);
+  const [primaryColor, setPrimaryColor] = useState(DEFAULT_EVENT_THEME.primary);
+  const [secondaryColor, setSecondaryColor] = useState(DEFAULT_EVENT_THEME.secondary);
+  const [backgroundColor, setBackgroundColor] = useState(DEFAULT_EVENT_THEME.background);
+  const [textColor, setTextColor] = useState(DEFAULT_EVENT_THEME.text);
+  const [backgroundImage, setBackgroundImage] = useState<string | undefined>(undefined);
+  const [heroImages, setHeroImages] = useState<string[]>([]);
   const navigate = useNavigate();
 
   const handleStartDateChange = (d: Date | null) => {
@@ -44,6 +66,7 @@ const CreateEvent: React.FC<CreateEventProps> = ({ events, addEvent, deleteEvent
     }
 
     const eventId = generateEventId();
+    const shareToken = generateEventId();
     const newEvent: Event = {
       id: eventId,
       title,
@@ -55,10 +78,55 @@ const CreateEvent: React.FC<CreateEventProps> = ({ events, addEvent, deleteEvent
       showGuestList,
       guests: [],
       password: password ? password : undefined,
+      allowShareLink,
+      theme: {
+        primary: primaryColor,
+        secondary: secondaryColor,
+        background: backgroundColor,
+        text: textColor,
+      },
+      backgroundImage: backgroundImage || undefined,
+      heroImages: heroImages.length > 0 ? heroImages : undefined,
+      shareToken,
     };
 
     addEvent(newEvent);
     navigate(`/event/${eventId}`);
+  };
+
+  const handleBackgroundChange = async (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file) {
+      return;
+    }
+
+    try {
+      const dataUrl = await readFileAsDataUrl(file);
+      setBackgroundImage(dataUrl);
+    } catch (error) {
+      console.error('Unable to read background image', error);
+      alert('Could not load that background image. Please try a different file.');
+    }
+  };
+
+  const handleHeroImagesChange = async (event: React.ChangeEvent<HTMLInputElement>) => {
+    const files = event.target.files;
+    if (!files || files.length === 0) {
+      return;
+    }
+
+    try {
+      const dataUrls = await Promise.all(Array.from(files).map(readFileAsDataUrl));
+      setHeroImages(prev => [...prev, ...dataUrls]);
+      event.target.value = '';
+    } catch (error) {
+      console.error('Unable to read hero images', error);
+      alert('One or more images could not be loaded. Please try again.');
+    }
+  };
+
+  const handleRemoveHeroImage = (index: number) => {
+    setHeroImages(prev => prev.filter((_, idx) => idx !== index));
   };
 
   return (
@@ -113,6 +181,130 @@ const CreateEvent: React.FC<CreateEventProps> = ({ events, addEvent, deleteEvent
               <textarea id="message" value={message} onChange={(e) => setMessage(e.target.value)} rows={4} placeholder="e.g., Join us for a day of sun, food, and fun! You can use **Markdown** for formatting." className="w-full px-4 py-2 border border-slate-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary transition"></textarea>
             </div>
 
+            <div className="border-t border-b border-slate-200 py-6 space-y-6">
+              <div>
+                <h2 className="text-lg font-semibold text-slate-800">Appearance</h2>
+                <p className="text-sm text-slate-500">Customize the backdrop and colors guests will see on the invitation.</p>
+              </div>
+
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                <div className="space-y-2">
+                  <label htmlFor="primaryColor" className="text-sm font-semibold text-slate-700 flex justify-between items-center">
+                    Primary Accent Color
+                    <span className="font-normal text-xs text-slate-500">Buttons & highlights</span>
+                  </label>
+                  <input
+                    id="primaryColor"
+                    type="color"
+                    value={primaryColor}
+                    onChange={(e) => setPrimaryColor(e.target.value)}
+                    className="h-12 w-full rounded-lg border border-slate-300 cursor-pointer"
+                  />
+                </div>
+
+                <div className="space-y-2">
+                  <label htmlFor="secondaryColor" className="text-sm font-semibold text-slate-700 flex justify-between items-center">
+                    Secondary Accent Color
+                    <span className="font-normal text-xs text-slate-500">Hover & detail moments</span>
+                  </label>
+                  <input
+                    id="secondaryColor"
+                    type="color"
+                    value={secondaryColor}
+                    onChange={(e) => setSecondaryColor(e.target.value)}
+                    className="h-12 w-full rounded-lg border border-slate-300 cursor-pointer"
+                  />
+                </div>
+
+                <div className="space-y-2">
+                  <label htmlFor="backgroundColor" className="text-sm font-semibold text-slate-700 flex justify-between items-center">
+                    Background Tint
+                    <span className="font-normal text-xs text-slate-500">Visible when no image is set</span>
+                  </label>
+                  <input
+                    id="backgroundColor"
+                    type="color"
+                    value={backgroundColor}
+                    onChange={(e) => setBackgroundColor(e.target.value)}
+                    className="h-12 w-full rounded-lg border border-slate-300 cursor-pointer"
+                  />
+                </div>
+
+                <div className="space-y-2">
+                  <label htmlFor="textColor" className="text-sm font-semibold text-slate-700 flex justify-between items-center">
+                    Text Color
+                    <span className="font-normal text-xs text-slate-500">Headings & descriptions</span>
+                  </label>
+                  <input
+                    id="textColor"
+                    type="color"
+                    value={textColor}
+                    onChange={(e) => setTextColor(e.target.value)}
+                    className="h-12 w-full rounded-lg border border-slate-300 cursor-pointer"
+                  />
+                </div>
+              </div>
+
+              <div className="space-y-4">
+                <div className="space-y-2">
+                  <label htmlFor="backgroundImage" className="text-sm font-semibold text-slate-700 flex flex-col">
+                    Page Background (Optional)
+                    <span className="font-normal text-xs text-slate-500">A full-screen image behind your invitation</span>
+                  </label>
+                  <input
+                    id="backgroundImage"
+                    type="file"
+                    accept="image/*"
+                    onChange={handleBackgroundChange}
+                    className="block w-full text-sm text-slate-500 file:mr-4 file:py-2 file:px-4 file:rounded-lg file:border-0 file:text-sm file:font-semibold file:bg-primary file:text-white hover:file:bg-primary-700"
+                  />
+                  {backgroundImage && (
+                    <div className="rounded-xl overflow-hidden border border-slate-200">
+                      <img src={backgroundImage} alt="Background preview" className="w-full h-40 object-cover" />
+                      <button
+                        type="button"
+                        onClick={() => setBackgroundImage(undefined)}
+                        className="w-full bg-slate-100 text-slate-600 text-sm font-semibold py-2 hover:bg-slate-200 transition"
+                      >
+                        Remove background
+                      </button>
+                    </div>
+                  )}
+                </div>
+
+                <div className="space-y-2">
+                  <label htmlFor="heroImages" className="text-sm font-semibold text-slate-700 flex flex-col">
+                    Hero Photos (Optional)
+                    <span className="font-normal text-xs text-slate-500">Add one photo for a banner or multiple for a slideshow</span>
+                  </label>
+                  <input
+                    id="heroImages"
+                    type="file"
+                    accept="image/*"
+                    multiple
+                    onChange={handleHeroImagesChange}
+                    className="block w-full text-sm text-slate-500 file:mr-4 file:py-2 file:px-4 file:rounded-lg file:border-0 file:text-sm file:font-semibold file:bg-primary file:text-white hover:file:bg-primary-700"
+                  />
+                  {heroImages.length > 0 && (
+                    <div className="grid grid-cols-2 gap-3">
+                      {heroImages.map((image, index) => (
+                        <div key={`${image}-${index}`} className="relative rounded-xl overflow-hidden border border-slate-200">
+                          <img src={image} alt={`Hero preview ${index + 1}`} className="w-full h-32 object-cover" />
+                          <button
+                            type="button"
+                            onClick={() => handleRemoveHeroImage(index)}
+                            className="absolute top-2 right-2 bg-white/90 text-slate-700 text-xs font-semibold px-2 py-1 rounded-full shadow"
+                          >
+                            Remove
+                          </button>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              </div>
+            </div>
+
             <div className="border-t border-b border-slate-200 py-6 space-y-4">
               <div className="space-y-2">
                 <label htmlFor="password" className="text-sm font-semibold text-slate-700 flex flex-col">
@@ -122,14 +314,26 @@ const CreateEvent: React.FC<CreateEventProps> = ({ events, addEvent, deleteEvent
                 <input id="password" type="password" value={password} onChange={(e) => setPassword(e.target.value)} placeholder="Enter a password" className="w-full px-4 py-2 border border-slate-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary transition" />
               </div>
 
-              <div className="flex items-center justify-between">
-                <label htmlFor="showGuestList" className="text-sm font-semibold text-slate-700 flex flex-col">
-                  Show Guest List
-                  <span className="font-normal text-xs text-slate-500">If unchecked, only the number of guests will be shown.</span>
-                </label>
-                <div className="relative inline-block w-10 mr-2 align-middle select-none transition duration-200 ease-in">
-                  <input type="checkbox" id="showGuestList" checked={showGuestList} onChange={(e) => setShowGuestList(e.target.checked)} className="toggle-checkbox absolute block w-6 h-6 rounded-full bg-white border-4 appearance-none cursor-pointer"/>
-                  <label htmlFor="showGuestList" className="toggle-label block overflow-hidden h-6 rounded-full bg-slate-300 cursor-pointer"></label>
+              <div className="space-y-4">
+                <div className="flex items-center justify-between">
+                  <label htmlFor="showGuestList" className="text-sm font-semibold text-slate-700 flex flex-col">
+                    Show Guest List
+                    <span className="font-normal text-xs text-slate-500">If unchecked, only the number of guests will be shown.</span>
+                  </label>
+                  <div className="relative inline-block w-10 mr-2 align-middle select-none transition duration-200 ease-in">
+                    <input type="checkbox" id="showGuestList" checked={showGuestList} onChange={(e) => setShowGuestList(e.target.checked)} className="toggle-checkbox absolute block w-6 h-6 rounded-full bg-white border-4 appearance-none cursor-pointer"/>
+                    <label htmlFor="showGuestList" className="toggle-label block overflow-hidden h-6 rounded-full bg-slate-300 cursor-pointer"></label>
+                  </div>
+                </div>
+                <div className="flex items-center justify-between">
+                  <label htmlFor="allowShareLink" className="text-sm font-semibold text-slate-700 flex flex-col">
+                    Allow Shareable Link Button
+                    <span className="font-normal text-xs text-slate-500">Let guests copy a link that bypasses the password gate.</span>
+                  </label>
+                  <div className="relative inline-block w-10 mr-2 align-middle select-none transition duration-200 ease-in">
+                    <input type="checkbox" id="allowShareLink" checked={allowShareLink} onChange={(e) => setAllowShareLink(e.target.checked)} className="toggle-checkbox absolute block w-6 h-6 rounded-full bg-white border-4 appearance-none cursor-pointer"/>
+                    <label htmlFor="allowShareLink" className="toggle-label block overflow-hidden h-6 rounded-full bg-slate-300 cursor-pointer"></label>
+                  </div>
                 </div>
               </div>
             </div>

--- a/components/EditEvent.tsx
+++ b/components/EditEvent.tsx
@@ -1,12 +1,27 @@
 import React, { useState, useEffect } from 'react';
 import { useNavigate, useParams, Link } from 'react-router-dom';
 import type { Event } from '../types';
+import { DEFAULT_EVENT_THEME } from '../types';
 import DateTimePicker from './DateTimePicker';
 
 interface EditEventProps {
   events: Event[];
   editEvent: (event: Event) => void;
 }
+
+const readFileAsDataUrl = (file: File) =>
+  new Promise<string>((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      if (typeof reader.result === 'string') {
+        resolve(reader.result);
+      } else {
+        reject(new Error('Could not read file.'));
+      }
+    };
+    reader.onerror = () => reject(new Error('Could not read file.'));
+    reader.readAsDataURL(file);
+  });
 
 const EditEvent: React.FC<EditEventProps> = ({ events, editEvent }) => {
   const { eventId } = useParams<{ eventId: string }>();
@@ -21,6 +36,13 @@ const EditEvent: React.FC<EditEventProps> = ({ events, editEvent }) => {
   const [message, setMessage] = useState('');
   const [showGuestList, setShowGuestList] = useState(true);
   const [password, setPassword] = useState('');
+  const [allowShareLink, setAllowShareLink] = useState(true);
+  const [primaryColor, setPrimaryColor] = useState(DEFAULT_EVENT_THEME.primary);
+  const [secondaryColor, setSecondaryColor] = useState(DEFAULT_EVENT_THEME.secondary);
+  const [backgroundColor, setBackgroundColor] = useState(DEFAULT_EVENT_THEME.background);
+  const [textColor, setTextColor] = useState(DEFAULT_EVENT_THEME.text);
+  const [backgroundImage, setBackgroundImage] = useState<string | undefined>(undefined);
+  const [heroImages, setHeroImages] = useState<string[]>([]);
 
   useEffect(() => {
     if (eventToEdit) {
@@ -32,6 +54,13 @@ const EditEvent: React.FC<EditEventProps> = ({ events, editEvent }) => {
       setMessage(eventToEdit.message);
       setShowGuestList(eventToEdit.showGuestList);
       setPassword(eventToEdit.password || '');
+      setAllowShareLink(eventToEdit.allowShareLink ?? true);
+      setPrimaryColor(eventToEdit.theme?.primary ?? DEFAULT_EVENT_THEME.primary);
+      setSecondaryColor(eventToEdit.theme?.secondary ?? DEFAULT_EVENT_THEME.secondary);
+      setBackgroundColor(eventToEdit.theme?.background ?? DEFAULT_EVENT_THEME.background);
+      setTextColor(eventToEdit.theme?.text ?? DEFAULT_EVENT_THEME.text);
+      setBackgroundImage(eventToEdit.backgroundImage);
+      setHeroImages(eventToEdit.heroImages ?? []);
     }
   }, [eventToEdit]);
 
@@ -59,10 +88,54 @@ const EditEvent: React.FC<EditEventProps> = ({ events, editEvent }) => {
       message,
       showGuestList,
       password: password ? password : undefined,
+      allowShareLink,
+      theme: {
+        primary: primaryColor,
+        secondary: secondaryColor,
+        background: backgroundColor,
+        text: textColor,
+      },
+      backgroundImage: backgroundImage || undefined,
+      heroImages: heroImages.length > 0 ? heroImages : undefined,
     };
 
     editEvent(updatedEvent);
     navigate(`/event/${eventId}`);
+  };
+
+  const handleBackgroundChange = async (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file) {
+      return;
+    }
+
+    try {
+      const dataUrl = await readFileAsDataUrl(file);
+      setBackgroundImage(dataUrl);
+    } catch (error) {
+      console.error('Unable to read background image', error);
+      alert('Could not load that background image. Please try a different file.');
+    }
+  };
+
+  const handleHeroImagesChange = async (event: React.ChangeEvent<HTMLInputElement>) => {
+    const files = event.target.files;
+    if (!files || files.length === 0) {
+      return;
+    }
+
+    try {
+      const dataUrls = await Promise.all(Array.from(files).map(readFileAsDataUrl));
+      setHeroImages(prev => [...prev, ...dataUrls]);
+      event.target.value = '';
+    } catch (error) {
+      console.error('Unable to read hero images', error);
+      alert('One or more images could not be loaded. Please try again.');
+    }
+  };
+
+  const handleRemoveHeroImage = (index: number) => {
+    setHeroImages(prev => prev.filter((_, idx) => idx !== index));
   };
 
   if (!eventToEdit) {
@@ -129,6 +202,130 @@ const EditEvent: React.FC<EditEventProps> = ({ events, editEvent }) => {
               <textarea id="message" value={message} onChange={(e) => setMessage(e.target.value)} rows={4} placeholder="e.g., Join us for a day of sun, food, and fun! You can use **Markdown** for formatting." className="w-full px-4 py-2 border border-slate-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary transition"></textarea>
             </div>
 
+            <div className="border-t border-b border-slate-200 py-6 space-y-6">
+              <div>
+                <h2 className="text-lg font-semibold text-slate-800">Appearance</h2>
+                <p className="text-sm text-slate-500">Refresh the visuals that appear on the public invitation page.</p>
+              </div>
+
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                <div className="space-y-2">
+                  <label htmlFor="primaryColor" className="text-sm font-semibold text-slate-700 flex justify-between items-center">
+                    Primary Accent Color
+                    <span className="font-normal text-xs text-slate-500">Buttons & highlights</span>
+                  </label>
+                  <input
+                    id="primaryColor"
+                    type="color"
+                    value={primaryColor}
+                    onChange={(e) => setPrimaryColor(e.target.value)}
+                    className="h-12 w-full rounded-lg border border-slate-300 cursor-pointer"
+                  />
+                </div>
+
+                <div className="space-y-2">
+                  <label htmlFor="secondaryColor" className="text-sm font-semibold text-slate-700 flex justify-between items-center">
+                    Secondary Accent Color
+                    <span className="font-normal text-xs text-slate-500">Hover & detail moments</span>
+                  </label>
+                  <input
+                    id="secondaryColor"
+                    type="color"
+                    value={secondaryColor}
+                    onChange={(e) => setSecondaryColor(e.target.value)}
+                    className="h-12 w-full rounded-lg border border-slate-300 cursor-pointer"
+                  />
+                </div>
+
+                <div className="space-y-2">
+                  <label htmlFor="backgroundColor" className="text-sm font-semibold text-slate-700 flex justify-between items-center">
+                    Background Tint
+                    <span className="font-normal text-xs text-slate-500">Visible when no image is set</span>
+                  </label>
+                  <input
+                    id="backgroundColor"
+                    type="color"
+                    value={backgroundColor}
+                    onChange={(e) => setBackgroundColor(e.target.value)}
+                    className="h-12 w-full rounded-lg border border-slate-300 cursor-pointer"
+                  />
+                </div>
+
+                <div className="space-y-2">
+                  <label htmlFor="textColor" className="text-sm font-semibold text-slate-700 flex justify-between items-center">
+                    Text Color
+                    <span className="font-normal text-xs text-slate-500">Headings & descriptions</span>
+                  </label>
+                  <input
+                    id="textColor"
+                    type="color"
+                    value={textColor}
+                    onChange={(e) => setTextColor(e.target.value)}
+                    className="h-12 w-full rounded-lg border border-slate-300 cursor-pointer"
+                  />
+                </div>
+              </div>
+
+              <div className="space-y-4">
+                <div className="space-y-2">
+                  <label htmlFor="backgroundImage" className="text-sm font-semibold text-slate-700 flex flex-col">
+                    Page Background (Optional)
+                    <span className="font-normal text-xs text-slate-500">A full-screen image behind your invitation</span>
+                  </label>
+                  <input
+                    id="backgroundImage"
+                    type="file"
+                    accept="image/*"
+                    onChange={handleBackgroundChange}
+                    className="block w-full text-sm text-slate-500 file:mr-4 file:py-2 file:px-4 file:rounded-lg file:border-0 file:text-sm file:font-semibold file:bg-primary file:text-white hover:file:bg-primary-700"
+                  />
+                  {backgroundImage && (
+                    <div className="rounded-xl overflow-hidden border border-slate-200">
+                      <img src={backgroundImage} alt="Background preview" className="w-full h-40 object-cover" />
+                      <button
+                        type="button"
+                        onClick={() => setBackgroundImage(undefined)}
+                        className="w-full bg-slate-100 text-slate-600 text-sm font-semibold py-2 hover:bg-slate-200 transition"
+                      >
+                        Remove background
+                      </button>
+                    </div>
+                  )}
+                </div>
+
+                <div className="space-y-2">
+                  <label htmlFor="heroImages" className="text-sm font-semibold text-slate-700 flex flex-col">
+                    Hero Photos (Optional)
+                    <span className="font-normal text-xs text-slate-500">Add one photo for a banner or multiple for a slideshow</span>
+                  </label>
+                  <input
+                    id="heroImages"
+                    type="file"
+                    accept="image/*"
+                    multiple
+                    onChange={handleHeroImagesChange}
+                    className="block w-full text-sm text-slate-500 file:mr-4 file:py-2 file:px-4 file:rounded-lg file:border-0 file:text-sm file:font-semibold file:bg-primary file:text-white hover:file:bg-primary-700"
+                  />
+                  {heroImages.length > 0 && (
+                    <div className="grid grid-cols-2 gap-3">
+                      {heroImages.map((image, index) => (
+                        <div key={`${image}-${index}`} className="relative rounded-xl overflow-hidden border border-slate-200">
+                          <img src={image} alt={`Hero preview ${index + 1}`} className="w-full h-32 object-cover" />
+                          <button
+                            type="button"
+                            onClick={() => handleRemoveHeroImage(index)}
+                            className="absolute top-2 right-2 bg-white/90 text-slate-700 text-xs font-semibold px-2 py-1 rounded-full shadow"
+                          >
+                            Remove
+                          </button>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              </div>
+            </div>
+
             <div className="border-t border-b border-slate-200 py-6 space-y-4">
               <div className="space-y-2">
                 <label htmlFor="password" className="text-sm font-semibold text-slate-700 flex flex-col">
@@ -138,14 +335,26 @@ const EditEvent: React.FC<EditEventProps> = ({ events, editEvent }) => {
                 <input id="password" type="password" value={password} onChange={(e) => setPassword(e.target.value)} placeholder="Enter a password" className="w-full px-4 py-2 border border-slate-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary transition" />
               </div>
 
-              <div className="flex items-center justify-between">
-                <label htmlFor="showGuestList" className="text-sm font-semibold text-slate-700 flex flex-col">
-                  Show Guest List
-                  <span className="font-normal text-xs text-slate-500">If unchecked, only the number of guests will be shown.</span>
-                </label>
-                <div className="relative inline-block w-10 mr-2 align-middle select-none transition duration-200 ease-in">
-                  <input type="checkbox" id="showGuestList" checked={showGuestList} onChange={(e) => setShowGuestList(e.target.checked)} className="toggle-checkbox absolute block w-6 h-6 rounded-full bg-white border-4 appearance-none cursor-pointer"/>
-                  <label htmlFor="showGuestList" className="toggle-label block overflow-hidden h-6 rounded-full bg-slate-300 cursor-pointer"></label>
+              <div className="space-y-4">
+                <div className="flex items-center justify-between">
+                  <label htmlFor="showGuestList" className="text-sm font-semibold text-slate-700 flex flex-col">
+                    Show Guest List
+                    <span className="font-normal text-xs text-slate-500">If unchecked, only the number of guests will be shown.</span>
+                  </label>
+                  <div className="relative inline-block w-10 mr-2 align-middle select-none transition duration-200 ease-in">
+                    <input type="checkbox" id="showGuestList" checked={showGuestList} onChange={(e) => setShowGuestList(e.target.checked)} className="toggle-checkbox absolute block w-6 h-6 rounded-full bg-white border-4 appearance-none cursor-pointer"/>
+                    <label htmlFor="showGuestList" className="toggle-label block overflow-hidden h-6 rounded-full bg-slate-300 cursor-pointer"></label>
+                  </div>
+                </div>
+                <div className="flex items-center justify-between">
+                  <label htmlFor="allowShareLink" className="text-sm font-semibold text-slate-700 flex flex-col">
+                    Allow Shareable Link Button
+                    <span className="font-normal text-xs text-slate-500">Let guests copy a link that bypasses the password gate.</span>
+                  </label>
+                  <div className="relative inline-block w-10 mr-2 align-middle select-none transition duration-200 ease-in">
+                    <input type="checkbox" id="allowShareLink" checked={allowShareLink} onChange={(e) => setAllowShareLink(e.target.checked)} className="toggle-checkbox absolute block w-6 h-6 rounded-full bg-white border-4 appearance-none cursor-pointer"/>
+                    <label htmlFor="allowShareLink" className="toggle-label block overflow-hidden h-6 rounded-full bg-slate-300 cursor-pointer"></label>
+                  </div>
                 </div>
               </div>
             </div>

--- a/components/ProtectedAdminRoute.tsx
+++ b/components/ProtectedAdminRoute.tsx
@@ -1,0 +1,49 @@
+import React, { useMemo } from 'react';
+import { Navigate } from 'react-router-dom';
+
+interface ProtectedAdminRouteProps {
+  children: React.ReactElement;
+}
+
+const ADMIN_SESSION_KEY = 'admin-auth';
+
+export const isAdminAuthorized = () => {
+  try {
+    return typeof window !== 'undefined' && window.sessionStorage.getItem(ADMIN_SESSION_KEY) === 'true';
+  } catch (error) {
+    console.error('Unable to read admin session state:', error);
+    return false;
+  }
+};
+
+const ProtectedAdminRoute: React.FC<ProtectedAdminRouteProps> = ({ children }) => {
+  const isAuthorized = useMemo(isAdminAuthorized, []);
+
+  if (!isAuthorized) {
+    return <Navigate to="/" replace />;
+  }
+
+  return children;
+};
+
+export const setAdminAuthorized = () => {
+  try {
+    if (typeof window !== 'undefined') {
+      window.sessionStorage.setItem(ADMIN_SESSION_KEY, 'true');
+    }
+  } catch (error) {
+    console.error('Unable to persist admin session state:', error);
+  }
+};
+
+export const clearAdminAuthorization = () => {
+  try {
+    if (typeof window !== 'undefined') {
+      window.sessionStorage.removeItem(ADMIN_SESSION_KEY);
+    }
+  } catch (error) {
+    console.error('Unable to clear admin session state:', error);
+  }
+};
+
+export default ProtectedAdminRoute;

--- a/components/ProtectedEventView.tsx
+++ b/components/ProtectedEventView.tsx
@@ -1,8 +1,9 @@
-import React, { useState, useMemo, useEffect } from 'react';
-import { useParams, Link } from 'react-router-dom';
+import React, { useState, useMemo, useEffect, useCallback } from 'react';
+import { useParams, Link, useSearchParams } from 'react-router-dom';
 import type { Event, Guest } from '../types';
 import ViewEvent from './ViewEvent';
 import PasswordPrompt from './PasswordPrompt';
+import { isAdminAuthorized } from './ProtectedAdminRoute';
 
 interface ProtectedEventViewProps {
   events: Event[];
@@ -11,35 +12,68 @@ interface ProtectedEventViewProps {
 
 const ProtectedEventView: React.FC<ProtectedEventViewProps> = ({ events, addRsvp }) => {
   const { eventId } = useParams<{ eventId: string }>();
+  const [searchParams] = useSearchParams();
   
   const event = useMemo(() => events.find(e => e.id === eventId), [events, eventId]);
   const sessionKey = `event-auth-${eventId}`;
   
   // Check session storage for prior authorization
   const isInitiallyAuthorized = () => {
-      if (!event || !event.password) return true;
-      try {
-        return sessionStorage.getItem(sessionKey) === 'true';
-      } catch (e) {
-        console.error('Could not access session storage:', e);
+    if (!event || !event.password) return true;
+    try {
+      if (typeof window === 'undefined') {
         return false;
       }
+      if (window.sessionStorage.getItem(sessionKey) === 'true') {
+        return true;
+      }
+      const guestToken = searchParams.get('guest');
+      const shareToken = event.shareToken ?? event.id;
+      if (guestToken && shareToken && guestToken === shareToken) {
+        window.sessionStorage.setItem(sessionKey, 'true');
+        return true;
+      }
+      return false;
+    } catch (e) {
+      console.error('Could not access session storage:', e);
+      return false;
+    }
   };
 
   const [isAuthorized, setIsAuthorized] = useState(isInitiallyAuthorized);
-  
+
+  const persistAuthorization = useCallback(() => {
+    try {
+      if (typeof window !== 'undefined') {
+        window.sessionStorage.setItem(sessionKey, 'true');
+      }
+    } catch (e) {
+      console.error('Could not set item in session storage:', e);
+    }
+    setIsAuthorized(true);
+  }, [sessionKey]);
+
   // Effect to re-evaluate authorization if the event or its password changes
   useEffect(() => {
     setIsAuthorized(isInitiallyAuthorized());
   }, [event, eventId]);
 
-  const handleCorrectPassword = () => {
-    try {
-      sessionStorage.setItem(sessionKey, 'true');
-    } catch(e) {
-        console.error('Could not set item in session storage:', e);
+  useEffect(() => {
+    if (!event) {
+      return;
     }
-    setIsAuthorized(true);
+    const guestToken = searchParams.get('guest');
+    if (!guestToken) {
+      return;
+    }
+    const shareToken = event.shareToken ?? event.id;
+    if (guestToken && shareToken && guestToken === shareToken) {
+      persistAuthorization();
+    }
+  }, [event, persistAuthorization, searchParams]);
+
+  const handleCorrectPassword = () => {
+    persistAuthorization();
   };
 
   if (!event) {
@@ -64,7 +98,9 @@ const ProtectedEventView: React.FC<ProtectedEventViewProps> = ({ events, addRsvp
     );
   }
 
-  return <ViewEvent events={events} addRsvp={addRsvp} />;
+  const adminAuthorized = isAdminAuthorized();
+
+  return <ViewEvent events={events} addRsvp={addRsvp} isAdmin={adminAuthorized} />;
 };
 
 export default ProtectedEventView;

--- a/components/icons.tsx
+++ b/components/icons.tsx
@@ -49,8 +49,51 @@ export const LockClosedIcon = ({ className }: { className?: string }) => (
   </svg>
 );
 
+export const DirectionsIcon = ({ className }: { className?: string }) => (
+  <svg xmlns="http://www.w3.org/2000/svg" className={className} fill="none" viewBox="0 0 24 24" stroke="currentColor">
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth={2}
+      d="M12.707 2.293a1 1 0 00-1.414 0l-9 9a1 1 0 000 1.414l9 9a1 1 0 001.414 0l9-9a1 1 0 000-1.414l-9-9z"
+    />
+    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v8m0 0l3-3m-3 3l-3-3" />
+  </svg>
+);
+
 export const TrashIcon = ({ className }: { className?: string }) => (
   <svg xmlns="http://www.w3.org/2000/svg" className={className} fill="none" viewBox="0 0 24 24" stroke="currentColor">
     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6M4 7h16M9 4h6a1 1 0 011 1v1H8V5a1 1 0 011-1z" />
+  </svg>
+);
+
+export const PlusIcon = ({ className }: { className?: string }) => (
+  <svg xmlns="http://www.w3.org/2000/svg" className={className} fill="none" viewBox="0 0 24 24" stroke="currentColor">
+    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+  </svg>
+);
+
+export const ArrowRightIcon = ({ className }: { className?: string }) => (
+  <svg xmlns="http://www.w3.org/2000/svg" className={className} fill="none" viewBox="0 0 24 24" stroke="currentColor">
+    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+  </svg>
+);
+
+export const ChevronLeftIcon = ({ className }: { className?: string }) => (
+  <svg xmlns="http://www.w3.org/2000/svg" className={className} fill="none" viewBox="0 0 24 24" stroke="currentColor">
+    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+  </svg>
+);
+
+export const ChevronRightIcon = ({ className }: { className?: string }) => (
+  <svg xmlns="http://www.w3.org/2000/svg" className={className} fill="none" viewBox="0 0 24 24" stroke="currentColor">
+    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+  </svg>
+);
+
+export const XCircleIcon = ({ className }: { className?: string }) => (
+  <svg xmlns="http://www.w3.org/2000/svg" className={className} fill="none" viewBox="0 0 24 24" stroke="currentColor">
+    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2" />
+    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
   </svg>
 );

--- a/types.ts
+++ b/types.ts
@@ -5,7 +5,22 @@ export interface Guest {
   comment: string;
   email?: string;
   status: 'attending' | 'not-attending';
+  respondedAt?: string;
 }
+
+export interface EventTheme {
+  primary: string;
+  secondary: string;
+  background: string;
+  text: string;
+}
+
+export const DEFAULT_EVENT_THEME: EventTheme = {
+  primary: '#4f46e5',
+  secondary: '#6366f1',
+  background: '#eef2ff',
+  text: '#1e293b',
+};
 
 export interface Event {
   id: string;
@@ -18,4 +33,9 @@ export interface Event {
   showGuestList: boolean;
   guests: Guest[];
   password?: string;
+  theme?: EventTheme;
+  backgroundImage?: string;
+  heroImages?: string[];
+  allowShareLink?: boolean;
+  shareToken?: string;
 }


### PR DESCRIPTION
## Summary
- guard admin-only flows by issuing share tokens, persisting guest sessions, and wrapping the edit page in the existing admin gate
- let hosts toggle the share-link button, capture RSVP timestamps, add map directions, and only surface edit tools to admins on the event view
- surface the latest RSVP comments and attendance changes directly on the admin dashboard for quick review

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cda97c4bc8832d8bd1fce21625b7f4