### PR TITLE
feat: add MySQL-backed API and admin auth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,42 @@
+# --------- Front-end configuration ---------
+# Base URL where the API is available.
+VITE_API_BASE_URL=http://localhost:4000
+
+# --------- Database configuration ---------
+# Provide DATABASE_URL or the individual DB_* settings.
+# DATABASE_URL=mysql://user:password@localhost:3306/party_inviter
+DB_HOST=localhost
+DB_PORT=3306
+DB_USER=root
+DB_PASSWORD=
+DB_NAME=party_inviter
+DB_CONNECTION_LIMIT=10
+# DB_SSL=true
+
+# --------- Authentication ---------
+# Plain text admin password OR a bcrypt hash. Only set one of these.
+ADMIN_PASSWORD=admin123
+# ADMIN_PASSWORD_HASH=$2a$10$example-hash
+ADMIN_JWT_SECRET=change-me-admin
+GUEST_JWT_SECRET=change-me-guest
+BCRYPT_ROUNDS=10
+
+# --------- Server configuration ---------
+PORT=4000
+CORS_ORIGIN=http://localhost:5173
+
+# --------- Email notifications ---------
+# Configure either SMTP or Mailgun (or both). Set MAIL_TO to enable notifications.
+MAIL_TO=
+MAIL_FROM="Party Inviter <no-reply@example.com>"
+
+# SMTP settings
+SMTP_HOST=
+SMTP_PORT=587
+SMTP_SECURE=false
+SMTP_USER=
+SMTP_PASSWORD=
+
+# Mailgun settings
+MAILGUN_API_KEY=
+MAILGUN_DOMAIN=

--- a/App.tsx
+++ b/App.tsx
@@ -1,135 +1,158 @@
 import React from 'react';
 import { HashRouter, Routes, Route, Link } from 'react-router-dom';
-import type { Event, Guest } from './types';
-import useLocalStorage from './hooks/useLocalStorage';
+import { AdminProvider, useAdminContext } from './contexts/AdminContext';
+import AccessGate from './components/AccessGate';
+import ProtectedAdminRoute from './components/ProtectedAdminRoute';
+import AdminDashboard from './components/AdminDashboard';
 import CreateEvent from './components/CreateEvent';
 import EditEvent from './components/EditEvent';
 import ProtectedEventView from './components/ProtectedEventView';
-import AccessGate from './components/AccessGate';
-import ProtectedAdminRoute, { setAdminAuthorized } from './components/ProtectedAdminRoute';
-import AdminDashboard from './components/AdminDashboard';
+import type { Event } from './types';
+import {
+  submitAccessPassword,
+  createEvent as createEventRequest,
+  updateEvent as updateEventRequest,
+  deleteEvent as deleteEventRequest,
+  type EventPayload,
+} from './lib/api';
 
-const generateShareToken = () => {
-  if (typeof window !== 'undefined' && window.crypto?.randomUUID) {
-    return window.crypto.randomUUID().replace(/-/g, '').slice(0, 12);
+const App: React.FC = () => (
+  <AdminProvider>
+    <HashRouter>
+      <AppContent />
+    </HashRouter>
+  </AdminProvider>
+);
+
+const updateEventList = (events: Event[], updatedEvent: Event) => {
+  const exists = events.some(event => event.id === updatedEvent.id);
+  if (exists) {
+    return events.map(event => (event.id === updatedEvent.id ? updatedEvent : event));
   }
-  return Math.random().toString(36).substring(2, 14);
+  return [...events, updatedEvent];
 };
 
-const App: React.FC = () => {
-  const [events, setEvents] = useLocalStorage<Event[]>('party-events', []);
-  const adminPassword = import.meta.env.VITE_ADMIN_PASSWORD || 'admin123';
+const AppContent: React.FC = () => {
+  const { token: adminToken, isAdmin, events, setEvents, setToken, refreshEvents, clearSession } = useAdminContext();
 
-  React.useEffect(() => {
-    if (events.length === 0) {
-      return;
-    }
+  const handleAdminAuthorized = React.useCallback(
+    (token: string) => {
+      setToken(token);
+      void refreshEvents();
+    },
+    [setToken, refreshEvents],
+  );
 
-    const needsToken = events.some(event => !event.shareToken);
-    if (needsToken) {
-      setEvents(prevEvents =>
-        prevEvents.map(event =>
-          event.shareToken ? event : { ...event, shareToken: generateShareToken() }
-        )
-      );
-    }
-  }, [events, setEvents]);
-  const addEvent = (event: Event) => {
-    setEvents(prevEvents => [...prevEvents, event]);
-  };
-
-  const editEvent = (updatedEvent: Event) => {
-    setEvents(prevEvents =>
-      prevEvents.map(event =>
-        event.id === updatedEvent.id ? updatedEvent : event
-      )
-    );
-  };
-
-  const addRsvp = (eventId: string, guest: Guest) => {
-    setEvents(prevEvents =>
-      prevEvents.map(event =>
-        event.id === eventId
-          ? {
-              ...event,
-              guests: [
-                ...event.guests,
-                {
-                  ...guest,
-                  respondedAt: guest.respondedAt ?? new Date().toISOString(),
-                },
-              ],
-            }
-          : event
-      )
-    );
-  };
-
-  const deleteEvent = (eventId: string) => {
-    setEvents(prevEvents => prevEvents.filter(event => event.id !== eventId));
-    if (typeof window !== 'undefined' && window.sessionStorage) {
-      try {
-        window.sessionStorage.removeItem(`event-auth-${eventId}`);
-      } catch (error) {
-        console.error('Failed to clear session storage for event:', error);
+  const handleEventCreated = React.useCallback(
+    async (payload: EventPayload) => {
+      if (!adminToken) {
+        throw new Error('Admin session expired. Please sign in again.');
       }
-    }
-  };
+      const newEvent = await createEventRequest(adminToken, payload);
+      setEvents(prevEvents => [...prevEvents, newEvent]);
+      return newEvent;
+    },
+    [adminToken, setEvents],
+  );
+
+  const handleEventUpdated = React.useCallback(
+    async (eventId: string, payload: EventPayload) => {
+      if (!adminToken) {
+        throw new Error('Admin session expired. Please sign in again.');
+      }
+      const updatedEvent = await updateEventRequest(adminToken, eventId, payload);
+      setEvents(prevEvents => updateEventList(prevEvents, updatedEvent));
+      return updatedEvent;
+    },
+    [adminToken, setEvents],
+  );
+
+  const handleEventDeleted = React.useCallback(
+    async (eventId: string) => {
+      if (!adminToken) {
+        throw new Error('Admin session expired. Please sign in again.');
+      }
+      await deleteEventRequest(adminToken, eventId);
+      setEvents(prevEvents => prevEvents.filter(event => event.id !== eventId));
+    },
+    [adminToken, setEvents],
+  );
+
+  const handleAdminLogout = React.useCallback(() => {
+    clearSession();
+  }, [clearSession]);
+
+  const handleEventSynced = React.useCallback(
+    (event: Event) => {
+      setEvents(prevEvents => updateEventList(prevEvents, event));
+    },
+    [setEvents],
+  );
 
   return (
-    <HashRouter>
-      <div className="min-h-screen flex flex-col font-sans">
-        <header className="p-4 bg-white/80 backdrop-blur-md sticky top-0 border-b border-slate-200">
-            <nav className="max-w-6xl mx-auto flex justify-center">
-            <Link to="/" className="text-2xl align-center font-bold text-primary hover:text-primary-700 transition">
-              Joe's Lame Party Invite Sender Thing
-            </Link>
-            </nav>
-        </header>
-        <main className="flex-grow">
-          <Routes>
-            <Route
-              path="/"
-              element={
-                <AccessGate
+    <div className="min-h-screen flex flex-col font-sans">
+      <header className="p-4 bg-white/80 backdrop-blur-md sticky top-0 border-b border-slate-200">
+        <nav className="max-w-6xl mx-auto flex justify-center">
+          <Link to="/" className="text-2xl align-center font-bold text-primary hover:text-primary-700 transition">
+            Joe's Lame Party Invite Sender Thing
+          </Link>
+        </nav>
+      </header>
+      <main className="flex-grow">
+        <Routes>
+          <Route
+            path="/"
+            element={
+              <AccessGate
+                onAdminAuthorized={handleAdminAuthorized}
+                submitAccessPassword={submitAccessPassword}
+              />
+            }
+          />
+          <Route
+            path="/admin"
+            element={
+              <ProtectedAdminRoute>
+                <AdminDashboard onLogout={handleAdminLogout} />
+              </ProtectedAdminRoute>
+            }
+          />
+          <Route
+            path="/create"
+            element={
+              <ProtectedAdminRoute>
+                <CreateEvent
                   events={events}
-                  adminPassword={adminPassword}
-                  onAdminAuthorized={setAdminAuthorized}
+                  onCreate={handleEventCreated}
+                  onDelete={handleEventDeleted}
                 />
-              }
-            />
-            <Route
-              path="/admin"
-              element={
-                <ProtectedAdminRoute>
-                  <AdminDashboard events={events} />
-                </ProtectedAdminRoute>
-              }
-            />
-            <Route
-              path="/create"
-              element={
-                <ProtectedAdminRoute>
-                  <CreateEvent events={events} addEvent={addEvent} deleteEvent={deleteEvent} />
-                </ProtectedAdminRoute>
-              }
-            />
-            <Route path="/event/:eventId" element={<ProtectedEventView events={events} addRsvp={addRsvp} />} />
-            <Route
-              path="/event/:eventId/edit"
-              element={
-                <ProtectedAdminRoute>
-                  <EditEvent events={events} editEvent={editEvent} />
-                </ProtectedAdminRoute>
-              }
-            />
-          </Routes>
-        </main>
-        <footer className="text-center py-4 text-slate-500 text-sm">
-          <p>copyright two-thousand twenty-five</p>
-        </footer>
-      </div>
-    </HashRouter>
+              </ProtectedAdminRoute>
+            }
+          />
+          <Route
+            path="/event/:eventId"
+            element={
+              <ProtectedEventView
+                adminEvents={events}
+                isAdmin={isAdmin}
+                onEventUpdated={handleEventSynced}
+              />
+            }
+          />
+          <Route
+            path="/event/:eventId/edit"
+            element={
+              <ProtectedAdminRoute>
+                <EditEvent events={events} onSave={handleEventUpdated} />
+              </ProtectedAdminRoute>
+            }
+          />
+        </Routes>
+      </main>
+      <footer className="text-center py-4 text-slate-500 text-sm">
+        <p>copyright two-thousand twenty-five</p>
+      </footer>
+    </div>
   );
 };
 

--- a/README.md
+++ b/README.md
@@ -10,25 +10,52 @@ View your app in AI Studio: https://ai.studio/apps/drive/19mi9HO88ttJri_mR9qvzq2
 
 ## Run Locally
 
-**Prerequisites:**  Node.js
+**Prerequisites:** Node.js 18+, npm, and a MySQL 8.0+ database.
 
-
-1. Install dependencies:
-   `npm install`
-2. (Optional) Set the admin password by defining `VITE_ADMIN_PASSWORD` in [.env.local](.env.local). The default value is `admin123`.
-3. Set the `GEMINI_API_KEY` in [.env.local](.env.local) to your Gemini API key
-4. Run the app:
-   `npm run dev`
+1. Install front-end dependencies:
+   ```bash
+   npm install
+   ```
+2. Install API dependencies:
+   ```bash
+   cd server
+   npm install
+   cd ..
+   ```
+3. Copy the example environment file and adjust the values for your environment:
+   ```bash
+   cp .env.example .env
+   ```
+   The most important settings are:
+   * `DATABASE_URL` (or `DB_HOST`, `DB_USER`, `DB_PASSWORD`, `DB_NAME`) – connection info for MySQL. Tables are created automatically on boot.
+   * `ADMIN_PASSWORD` or `ADMIN_PASSWORD_HASH` – credentials required to access the admin dashboard.
+   * `ADMIN_JWT_SECRET` / `GUEST_JWT_SECRET` – secrets for signing JSON Web Tokens.
+   * `VITE_API_BASE_URL` – URL of the API server (defaults to `http://localhost:4000`).
+   * Optional email settings (`MAIL_TO`, `SMTP_*`, or Mailgun credentials) to receive RSVP notifications.
+4. Start the API server:
+   ```bash
+   npm run server
+   ```
+   The server listens on port `4000` by default.
+5. In a second terminal start the Vite dev server:
+   ```bash
+   npm run dev
+   ```
+6. Visit the front-end at http://localhost:5173/. Use the admin password from your `.env` file to unlock the dashboard.
 
 ## Run with Docker
 
-1. Build the production image (pass your Gemini key if needed):
+1. Build the production image (pass any required environment variables via build args or the runtime environment):
    ```bash
-   docker build -t party-inviter . --build-arg GEMINI_API_KEY=your-key-here
+   docker build -t party-inviter .
    ```
-2. Start the container:
+2. Start the container and provide the necessary environment variables (database credentials, admin password, etc.). Example:
    ```bash
-   docker run -d --name party-inviter -p 8080:80 party-inviter
+   docker run -d --name party-inviter \
+     -e DATABASE_URL="mysql://user:pass@db:3306/party_inviter" \
+     -e ADMIN_PASSWORD="super-secret" \
+     -e VITE_API_BASE_URL="http://localhost:4000" \
+     -p 4000:4000 -p 5173:80 party-inviter
    ```
 
-The site will be available at http://localhost:8080/ by default. On Unraid, point the Docker template to this repository, set the same build argument if you rely on the Gemini API key, and map container port 80 to an available host port.
+The API will be available on port 4000 and the front-end on port 80 (mapped to 5173 in the example above). Configure MySQL and any email credentials before deploying in production.

--- a/components/AdminDashboard.tsx
+++ b/components/AdminDashboard.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo } from 'react';
 import { Link } from 'react-router-dom';
+import { useAdminContext } from '../contexts/AdminContext';
 import type { Event } from '../types';
 import {
   CalendarIcon,
@@ -13,7 +14,7 @@ import {
 } from './icons';
 
 interface AdminDashboardProps {
-  events: Event[];
+  onLogout?: () => void;
 }
 
 const formatDateRange = (event: Event) => {
@@ -41,7 +42,9 @@ const formatDateRange = (event: Event) => {
   })}`;
 };
 
-const AdminDashboard: React.FC<AdminDashboardProps> = ({ events }) => {
+const AdminDashboard: React.FC<AdminDashboardProps> = ({ onLogout }) => {
+  const { events } = useAdminContext();
+
   const { upcomingEvents, pastEvents } = useMemo(() => {
     const now = new Date();
     const upcoming: Event[] = [];
@@ -70,7 +73,7 @@ const AdminDashboard: React.FC<AdminDashboardProps> = ({ events }) => {
           eventTitle: event.title,
           guest,
           respondedAt: guest.respondedAt ? new Date(guest.respondedAt).getTime() : 0,
-        }))
+        })),
       )
       .sort((a, b) => b.respondedAt - a.respondedAt)
       .slice(0, 6);
@@ -93,7 +96,7 @@ const AdminDashboard: React.FC<AdminDashboardProps> = ({ events }) => {
                 <h3 className="text-xl font-semibold text-slate-800 leading-tight">{event.title}</h3>
                 <p className="text-sm text-slate-500">Hosted by {event.host}</p>
               </div>
-              {event.password && (
+              {event.passwordProtected && (
                 <span className="inline-flex items-center gap-1 rounded-full bg-slate-100 text-slate-600 px-3 py-1 text-xs font-semibold">
                   <LockClosedIcon className="h-4 w-4" /> Private
                 </span>
@@ -138,12 +141,23 @@ const AdminDashboard: React.FC<AdminDashboardProps> = ({ events }) => {
               Manage invitations, review upcoming celebrations, and revisit past events all from one place.
             </p>
           </div>
-          <Link
-            to="/create"
-            className="inline-flex items-center justify-center gap-2 rounded-lg bg-primary text-white font-semibold py-3 px-5 hover:bg-primary-700 transition"
-          >
-            <PlusIcon className="h-5 w-5" /> Create a New Event
-          </Link>
+          <div className="flex gap-3">
+            {onLogout && (
+              <button
+                type="button"
+                onClick={onLogout}
+                className="inline-flex items-center justify-center gap-2 rounded-lg bg-slate-100 text-slate-700 font-semibold py-3 px-5 hover:bg-slate-200 transition"
+              >
+                Sign out
+              </button>
+            )}
+            <Link
+              to="/create"
+              className="inline-flex items-center justify-center gap-2 rounded-lg bg-primary text-white font-semibold py-3 px-5 hover:bg-primary-700 transition"
+            >
+              <PlusIcon className="h-5 w-5" /> Create a New Event
+            </Link>
+          </div>
         </div>
       </section>
 
@@ -198,48 +212,45 @@ const AdminDashboard: React.FC<AdminDashboardProps> = ({ events }) => {
           </ul>
         ) : (
           <div className="bg-white rounded-2xl shadow-lg shadow-slate-200 p-8 text-center text-slate-500">
-            <p>No RSVPs yet. Once guests respond you'll see them here.</p>
+            <p>No RSVPs yet. Share your invitations to start collecting responses.</p>
           </div>
         )}
       </section>
 
-      <section>
-        <header className="flex items-center justify-between gap-4 mb-6">
+      <section className="space-y-8">
+        <header className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
           <div>
-            <h2 className="text-2xl font-bold text-slate-800">Upcoming Events</h2>
-            <p className="text-sm text-slate-500">Stay ahead of the celebrations headed your way.</p>
+            <h2 className="text-2xl font-bold text-slate-800">Upcoming events</h2>
+            <p className="text-sm text-slate-500">Keep tabs on what’s coming next.</p>
           </div>
-          <span className="text-sm text-slate-500">{upcomingEvents.length} upcoming</span>
+          <span className="text-sm text-slate-500">{upcomingEvents.length} scheduled</span>
         </header>
-        {upcomingEvents.length > 0 ? (
-          <div className="grid gap-4 md:grid-cols-2">
-            {upcomingEvents.map(event => renderEventCard(event))}
+        {upcomingEvents.length === 0 ? (
+          <div className="bg-white rounded-2xl shadow-lg shadow-slate-200 p-8 text-center text-slate-500">
+            <p>You don’t have any upcoming events yet. Start by creating one!</p>
           </div>
         ) : (
-          <div className="bg-white rounded-2xl shadow-lg shadow-slate-200 p-8 text-center text-slate-500">
-            <p>No upcoming events yet. Start planning your next gathering!</p>
-            <Link to="/create" className="inline-flex items-center gap-2 text-primary font-semibold mt-4">
-              <PlusIcon className="h-4 w-4" /> Create an event
-            </Link>
+          <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+            {upcomingEvents.map(renderEventCard)}
           </div>
         )}
       </section>
 
-      <section>
-        <header className="flex items-center justify-between gap-4 mb-6">
+      <section className="space-y-8">
+        <header className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
           <div>
-            <h2 className="text-2xl font-bold text-slate-800">Past Events</h2>
-            <p className="text-sm text-slate-500">Look back at the memories you've already made.</p>
+            <h2 className="text-2xl font-bold text-slate-800">Past events</h2>
+            <p className="text-sm text-slate-500">Look back on memories from previous gatherings.</p>
           </div>
           <span className="text-sm text-slate-500">{pastEvents.length} archived</span>
         </header>
-        {pastEvents.length > 0 ? (
-          <div className="grid gap-4 md:grid-cols-2">
-            {pastEvents.map(event => renderEventCard(event))}
+        {pastEvents.length === 0 ? (
+          <div className="bg-white rounded-2xl shadow-lg shadow-slate-200 p-8 text-center text-slate-500">
+            <p>No past events yet. Once your events wrap up, they’ll appear here.</p>
           </div>
         ) : (
-          <div className="bg-white rounded-2xl shadow-lg shadow-slate-200 p-8 text-center text-slate-500">
-            <p>No past events yet. Share some invitations and see them appear here.</p>
+          <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+            {pastEvents.map(renderEventCard)}
           </div>
         )}
       </section>

--- a/components/PasswordPrompt.tsx
+++ b/components/PasswordPrompt.tsx
@@ -3,22 +3,32 @@ import { LockClosedIcon } from './icons';
 
 interface PasswordPromptProps {
   eventName: string;
-  correctPassword?: string;
-  onCorrectPassword: () => void;
+  onSubmit: (password: string) => Promise<void>;
 }
 
-const PasswordPrompt: React.FC<PasswordPromptProps> = ({ eventName, correctPassword, onCorrectPassword }) => {
+const PasswordPrompt: React.FC<PasswordPromptProps> = ({ eventName, onSubmit }) => {
   const [input, setInput] = useState('');
   const [error, setError] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (input === correctPassword) {
-      setError('');
-      onCorrectPassword();
-    } else {
-      setError('Incorrect password. Please try again.');
+    if (!input) {
+      setError('Please enter a password.');
+      return;
+    }
+
+    setIsSubmitting(true);
+    setError('');
+
+    try {
+      await onSubmit(input);
+    } catch (err) {
+      console.error('Incorrect password provided:', err);
+      setError(err instanceof Error ? err.message : 'Incorrect password. Please try again.');
       setInput('');
+    } finally {
+      setIsSubmitting(false);
     }
   };
 
@@ -32,21 +42,21 @@ const PasswordPrompt: React.FC<PasswordPromptProps> = ({ eventName, correctPassw
         <form onSubmit={handleSubmit} className="mt-6 space-y-4">
           <div className="space-y-2">
             <label htmlFor="password" className="sr-only">Password</label>
-            <input 
-              id="password" 
-              type="password" 
+            <input
+              id="password"
+              type="password"
               value={input} 
               onChange={(e) => setInput(e.target.value)} 
-              placeholder="Enter password" 
-              required 
+              placeholder="Enter password"
+              required
               autoFocus
-              className="w-full px-4 py-2 border border-slate-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary transition" 
+              className="w-full px-4 py-2 border border-slate-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary transition"
               aria-describedby="password-error"
             />
           </div>
           {error && <p id="password-error" className="text-sm text-red-600">{error}</p>}
           <button type="submit" className="w-full bg-primary text-white font-bold py-3 px-4 rounded-lg hover:bg-primary-700 focus:outline-none focus:ring-4 focus:ring-primary-300 transition-all duration-300">
-            Unlock Invitation
+            {isSubmitting ? 'Unlocking…' : 'Unlock Invitation'}
           </button>
         </form>
       </div>

--- a/components/ProtectedAdminRoute.tsx
+++ b/components/ProtectedAdminRoute.tsx
@@ -1,49 +1,19 @@
-import React, { useMemo } from 'react';
+import React from 'react';
 import { Navigate } from 'react-router-dom';
+import { useAdminContext } from '../contexts/AdminContext';
 
 interface ProtectedAdminRouteProps {
   children: React.ReactElement;
 }
 
-const ADMIN_SESSION_KEY = 'admin-auth';
-
-export const isAdminAuthorized = () => {
-  try {
-    return typeof window !== 'undefined' && window.sessionStorage.getItem(ADMIN_SESSION_KEY) === 'true';
-  } catch (error) {
-    console.error('Unable to read admin session state:', error);
-    return false;
-  }
-};
-
 const ProtectedAdminRoute: React.FC<ProtectedAdminRouteProps> = ({ children }) => {
-  const isAuthorized = useMemo(isAdminAuthorized, []);
+  const { isAdmin } = useAdminContext();
 
-  if (!isAuthorized) {
+  if (!isAdmin) {
     return <Navigate to="/" replace />;
   }
 
   return children;
-};
-
-export const setAdminAuthorized = () => {
-  try {
-    if (typeof window !== 'undefined') {
-      window.sessionStorage.setItem(ADMIN_SESSION_KEY, 'true');
-    }
-  } catch (error) {
-    console.error('Unable to persist admin session state:', error);
-  }
-};
-
-export const clearAdminAuthorization = () => {
-  try {
-    if (typeof window !== 'undefined') {
-      window.sessionStorage.removeItem(ADMIN_SESSION_KEY);
-    }
-  } catch (error) {
-    console.error('Unable to clear admin session state:', error);
-  }
 };
 
 export default ProtectedAdminRoute;

--- a/components/ProtectedEventView.tsx
+++ b/components/ProtectedEventView.tsx
@@ -1,106 +1,224 @@
-import React, { useState, useMemo, useEffect, useCallback } from 'react';
-import { useParams, Link, useSearchParams } from 'react-router-dom';
-import type { Event, Guest } from '../types';
+import React, { useEffect, useMemo, useState, useCallback } from 'react';
+import { useParams, useSearchParams, Link } from 'react-router-dom';
+import type { Event } from '../types';
 import ViewEvent from './ViewEvent';
 import PasswordPrompt from './PasswordPrompt';
-import { isAdminAuthorized } from './ProtectedAdminRoute';
+import { authorizeEventAccess, fetchPublicEvent, submitRsvp, type RsvpPayload } from '../lib/api';
+import { readGuestToken, storeGuestToken, storeManageToken, readManageToken } from '../lib/session';
 
 interface ProtectedEventViewProps {
-  events: Event[];
-  addRsvp: (eventId: string, guest: Guest) => void;
+  adminEvents: Event[];
+  isAdmin: boolean;
+  onEventUpdated: (event: Event) => void;
 }
 
-const ProtectedEventView: React.FC<ProtectedEventViewProps> = ({ events, addRsvp }) => {
+const ProtectedEventView: React.FC<ProtectedEventViewProps> = ({ adminEvents, isAdmin, onEventUpdated }) => {
   const { eventId } = useParams<{ eventId: string }>();
   const [searchParams] = useSearchParams();
-  
-  const event = useMemo(() => events.find(e => e.id === eventId), [events, eventId]);
-  const sessionKey = `event-auth-${eventId}`;
-  
-  // Check session storage for prior authorization
-  const isInitiallyAuthorized = () => {
-    if (!event || !event.password) return true;
-    try {
-      if (typeof window === 'undefined') {
-        return false;
-      }
-      if (window.sessionStorage.getItem(sessionKey) === 'true') {
-        return true;
-      }
-      const guestToken = searchParams.get('guest');
-      const shareToken = event.shareToken ?? event.id;
-      if (guestToken && shareToken && guestToken === shareToken) {
-        window.sessionStorage.setItem(sessionKey, 'true');
-        return true;
-      }
-      return false;
-    } catch (e) {
-      console.error('Could not access session storage:', e);
-      return false;
+  const shareTokenFromQuery = searchParams.get('guest');
+
+  const [event, setEvent] = useState<Event | null>(() => {
+    if (isAdmin && eventId) {
+      return adminEvents.find(evt => evt.id === eventId) ?? null;
     }
-  };
+    return null;
+  });
+  const [isLoading, setIsLoading] = useState(!event);
+  const [requiresPassword, setRequiresPassword] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [guestToken, setGuestTokenState] = useState<string | null>(() =>
+    eventId ? readGuestToken(eventId) : null,
+  );
+  const [manageToken, setManageTokenState] = useState<string | null>(() =>
+    eventId ? readManageToken(eventId) : null,
+  );
 
-  const [isAuthorized, setIsAuthorized] = useState(isInitiallyAuthorized);
+  const shareToken = shareTokenFromQuery || event?.shareToken || '';
 
-  const persistAuthorization = useCallback(() => {
-    try {
-      if (typeof window !== 'undefined') {
-        window.sessionStorage.setItem(sessionKey, 'true');
+  const syncEvent = useCallback(
+    (nextEvent: Event) => {
+      setEvent(nextEvent);
+      if (isAdmin) {
+        onEventUpdated(nextEvent);
       }
-    } catch (e) {
-      console.error('Could not set item in session storage:', e);
-    }
-    setIsAuthorized(true);
-  }, [sessionKey]);
-
-  // Effect to re-evaluate authorization if the event or its password changes
-  useEffect(() => {
-    setIsAuthorized(isInitiallyAuthorized());
-  }, [event, eventId]);
+    },
+    [isAdmin, onEventUpdated],
+  );
 
   useEffect(() => {
+    if (!isAdmin || !eventId) {
+      return;
+    }
+
+    const adminEvent = adminEvents.find(evt => evt.id === eventId);
+    if (adminEvent) {
+      setEvent(adminEvent);
+      setIsLoading(false);
+      setRequiresPassword(false);
+      setLoadError(null);
+    }
+  }, [adminEvents, eventId, isAdmin]);
+
+  useEffect(() => {
+    if (isAdmin) {
+      return;
+    }
+
+    if (!shareToken) {
+      setIsLoading(false);
+      setEvent(null);
+      setLoadError('This invitation link is missing a share token. Ask the host for a fresh link.');
+      return;
+    }
+
+    let cancelled = false;
+    const loadEvent = async () => {
+      setIsLoading(true);
+      try {
+        const { event: fetchedEvent, requiresPassword: needsPassword } = await fetchPublicEvent(
+          shareToken,
+          guestToken,
+        );
+
+        if (cancelled) {
+          return;
+        }
+
+        if (fetchedEvent) {
+          syncEvent(fetchedEvent);
+          setRequiresPassword(false);
+          setLoadError(null);
+        } else {
+          setEvent(null);
+          setRequiresPassword(needsPassword);
+        }
+      } catch (error) {
+        if (cancelled) {
+          return;
+        }
+        console.error('Unable to load event details:', error);
+        setEvent(null);
+        setLoadError('We could not load this event right now. Please try again later.');
+      } finally {
+        if (!cancelled) {
+          setIsLoading(false);
+        }
+      }
+    };
+
+    void loadEvent();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [guestToken, isAdmin, shareToken, syncEvent]);
+
+  const handlePasswordSubmit = useCallback(
+    async (password: string) => {
+      if (!shareToken) {
+        throw new Error('Missing share token for this event.');
+      }
+
+      const { guestToken: grantedToken, eventId: authorizedEventId } = await authorizeEventAccess(
+        shareToken,
+        password,
+      );
+
+      const idToStore = authorizedEventId || eventId || (event ? event.id : null);
+      if (idToStore) {
+        storeGuestToken(idToStore, grantedToken);
+      }
+      setGuestTokenState(grantedToken);
+
+      const { event: fetchedEvent } = await fetchPublicEvent(shareToken, grantedToken);
+      if (fetchedEvent) {
+        syncEvent(fetchedEvent);
+        setRequiresPassword(false);
+        setLoadError(null);
+      }
+    },
+    [event, eventId, shareToken, syncEvent],
+  );
+
+  const handleRsvpSubmit = useCallback(
+    async (payload: RsvpPayload) => {
+      if (!shareToken) {
+        throw new Error('Missing share token for this event.');
+      }
+
+      const response = await submitRsvp(shareToken, payload, guestToken, manageToken);
+      syncEvent(response.event);
+
+      const idToStore = eventId || response.event.id;
+      if (response.guestToken && idToStore) {
+        storeGuestToken(idToStore, response.guestToken);
+        setGuestTokenState(response.guestToken);
+      }
+
+      if (response.manageToken && idToStore) {
+        storeManageToken(idToStore, response.manageToken);
+        setManageTokenState(response.manageToken);
+      }
+
+      return response.guest;
+    },
+    [eventId, guestToken, manageToken, shareToken, syncEvent],
+  );
+
+  const content = useMemo(() => {
+    if (isLoading) {
+      return (
+        <div className="text-center p-10">
+          <p className="text-slate-500">Loading event details…</p>
+        </div>
+      );
+    }
+
+    if (loadError) {
+      return (
+        <div className="text-center p-10 space-y-4">
+          <h2 className="text-2xl font-bold text-slate-700">Something went wrong</h2>
+          <p className="text-slate-500">{loadError}</p>
+          <Link
+            to="/"
+            className="inline-block bg-primary text-white font-bold py-2 px-4 rounded-lg hover:bg-primary-700 transition"
+          >
+            Back to start
+          </Link>
+        </div>
+      );
+    }
+
     if (!event) {
-      return;
+      return (
+        <div className="text-center p-10">
+          <h2 className="text-2xl font-bold text-slate-700">Event Not Found</h2>
+          <p className="text-slate-500 mt-2">The link may be incorrect. Please check with the host.</p>
+          <Link
+            to="/"
+            className="mt-6 inline-block bg-primary text-white font-bold py-2 px-4 rounded-lg hover:bg-primary-700 transition"
+          >
+            Create a New Event
+          </Link>
+        </div>
+      );
     }
-    const guestToken = searchParams.get('guest');
-    if (!guestToken) {
-      return;
-    }
-    const shareToken = event.shareToken ?? event.id;
-    if (guestToken && shareToken && guestToken === shareToken) {
-      persistAuthorization();
-    }
-  }, [event, persistAuthorization, searchParams]);
 
-  const handleCorrectPassword = () => {
-    persistAuthorization();
-  };
+    if (!isAdmin && event.passwordProtected && requiresPassword) {
+      return <PasswordPrompt eventName={event.title} onSubmit={handlePasswordSubmit} />;
+    }
 
-  if (!event) {
     return (
-      <div className="text-center p-10">
-        <h2 className="text-2xl font-bold text-slate-700">Event Not Found</h2>
-        <p className="text-slate-500 mt-2">The link may be incorrect. Please check with the host.</p>
-        <Link to="/" className="mt-6 inline-block bg-primary text-white font-bold py-2 px-4 rounded-lg hover:bg-primary-700 transition">
-          Create a New Event
-        </Link>
-      </div>
-    );
-  }
-
-  if (!isAuthorized) {
-    return (
-      <PasswordPrompt 
-        eventName={event.title}
-        correctPassword={event.password}
-        onCorrectPassword={handleCorrectPassword}
+      <ViewEvent
+        event={event}
+        onSubmitRsvp={handleRsvpSubmit}
+        isAdmin={isAdmin}
+        shareToken={shareToken}
       />
     );
-  }
+  }, [event, handlePasswordSubmit, handleRsvpSubmit, isAdmin, isLoading, loadError, requiresPassword, shareToken]);
 
-  const adminAuthorized = isAdminAuthorized();
-
-  return <ViewEvent events={events} addRsvp={addRsvp} isAdmin={adminAuthorized} />;
+  return content;
 };
 
 export default ProtectedEventView;

--- a/components/ViewEvent.tsx
+++ b/components/ViewEvent.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
-import { useParams, Link } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import type { Event, Guest } from '../types';
@@ -16,6 +16,7 @@ import {
   ChevronRightIcon,
   DirectionsIcon,
 } from './icons';
+import type { RsvpPayload } from '../lib/api';
 
 const hexToRgba = (hex: string, alpha: number) => {
   const normalized = hex.replace('#', '');
@@ -43,17 +44,16 @@ const hexToRgba = (hex: string, alpha: number) => {
 };
 
 interface ViewEventProps {
-  events: Event[];
-  addRsvp: (eventId: string, guest: Guest) => void;
+  event: Event;
+  onSubmitRsvp: (payload: RsvpPayload) => Promise<Guest>;
   isAdmin: boolean;
+  shareToken: string;
 }
 
-const ADDRESS_PATTERN = /\b(street|st\.?|avenue|ave\.?|road|rd\.?|drive|dr\.?|boulevard|blvd\.?|lane|ln\.?|way|trail|court|ct\.?|circle|cir\.?|place|pl\.?)\b/i;
-
+const ADDRESS_PATTERN = /\b(street|st\.?|avenue|ave\.?|road|rd\.?|drive|dr\.?|boulevard|blvd\.?|lane|ln\.?|way|trail|court|ct\.?,?|circle|cir\.?|place|pl\.?)\b/i;
 const isLikelyAddress = (location: string) => /\d/.test(location) || ADDRESS_PATTERN.test(location);
 
-const ViewEvent: React.FC<ViewEventProps> = ({ events, addRsvp, isAdmin }) => {
-  const { eventId } = useParams<{ eventId: string }>();
+const ViewEvent: React.FC<ViewEventProps> = ({ event, onSubmitRsvp, isAdmin, shareToken }) => {
   const [name, setName] = useState('');
   const [plusOnes, setPlusOnes] = useState(0);
   const [comment, setComment] = useState('');
@@ -61,10 +61,9 @@ const ViewEvent: React.FC<ViewEventProps> = ({ events, addRsvp, isAdmin }) => {
   const [submitted, setSubmitted] = useState(false);
   const [linkCopied, setLinkCopied] = useState(false);
   const [rsvpChoice, setRsvpChoice] = useState<'yes' | 'no' | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
   const [currentSlide, setCurrentSlide] = useState(0);
   const copyTimeoutRef = useRef<number | null>(null);
-
-  const event = useMemo(() => events.find(e => e.id === eventId), [events, eventId]);
 
   useEffect(() => () => {
     if (copyTimeoutRef.current) {
@@ -84,24 +83,24 @@ const ViewEvent: React.FC<ViewEventProps> = ({ events, addRsvp, isAdmin }) => {
     }
   }, [rsvpChoice]);
 
-  const heroImages = useMemo(() => (event?.heroImages ?? []).filter(Boolean), [event]);
+  const heroImages = useMemo(() => (event.heroImages ?? []).filter(Boolean), [event.heroImages]);
 
   useEffect(() => {
     setCurrentSlide(0);
-  }, [eventId, heroImages.length]);
+  }, [event.id, heroImages.length]);
 
   const theme = useMemo(
     () => ({
-      primary: event?.theme?.primary ?? DEFAULT_EVENT_THEME.primary,
-      secondary: event?.theme?.secondary ?? DEFAULT_EVENT_THEME.secondary,
-      background: event?.theme?.background ?? DEFAULT_EVENT_THEME.background,
-      text: event?.theme?.text ?? DEFAULT_EVENT_THEME.text,
+      primary: event.theme?.primary ?? DEFAULT_EVENT_THEME.primary,
+      secondary: event.theme?.secondary ?? DEFAULT_EVENT_THEME.secondary,
+      background: event.theme?.background ?? DEFAULT_EVENT_THEME.background,
+      text: event.theme?.text ?? DEFAULT_EVENT_THEME.text,
     }),
-    [event]
+    [event.theme],
   );
 
   const backgroundStyle = useMemo<React.CSSProperties>(() => {
-    if (event?.backgroundImage) {
+    if (event.backgroundImage) {
       return {
         backgroundImage: `linear-gradient(rgba(255,255,255,0.88), rgba(255,255,255,0.9)), url(${event.backgroundImage})`,
         backgroundSize: 'cover',
@@ -110,37 +109,46 @@ const ViewEvent: React.FC<ViewEventProps> = ({ events, addRsvp, isAdmin }) => {
       };
     }
     return { backgroundColor: theme.background };
-  }, [event?.backgroundImage, theme.background]);
+  }, [event.backgroundImage, theme.background]);
 
   const mutedTextColor = useMemo(() => hexToRgba(theme.text, 0.78), [theme.text]);
   const subtleTextColor = useMemo(() => hexToRgba(theme.text, 0.6), [theme.text]);
   const dividerColor = useMemo(() => hexToRgba(theme.text, 0.15), [theme.text]);
   const softPrimary = useMemo(() => hexToRgba(theme.primary, 0.12), [theme.primary]);
 
-  const handleRsvpSubmit = (e: React.FormEvent) => {
+  const handleRsvpSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!name) {
       alert('Please enter your name.');
       return;
     }
+    if (!rsvpChoice) {
+      alert('Please tell us if you can make it.');
+      return;
+    }
 
-    if (event && rsvpChoice) {
-      const newGuest: Guest = {
-        id: Math.random().toString(36).substring(2, 10),
-        name,
-        plusOnes: rsvpChoice === 'yes' ? Math.max(0, plusOnes) : 0,
-        comment,
-        email: rsvpChoice === 'yes' && email ? email : undefined,
-        status: rsvpChoice === 'yes' ? 'attending' : 'not-attending',
-        respondedAt: new Date().toISOString(),
-      };
-      addRsvp(event.id, newGuest);
+    const payload: RsvpPayload = {
+      name,
+      plusOnes: rsvpChoice === 'yes' ? Math.max(0, plusOnes) : 0,
+      comment,
+      email: rsvpChoice === 'yes' && email ? email : undefined,
+      status: rsvpChoice === 'yes' ? 'attending' : 'not-attending',
+    };
+
+    try {
+      setIsSubmitting(true);
+      await onSubmitRsvp(payload);
       setSubmitted(true);
+    } catch (error) {
+      console.error('Unable to submit RSVP:', error);
+      alert('We could not save your RSVP. Please try again.');
+    } finally {
+      setIsSubmitting(false);
     }
   };
 
   const handleCopyLink = async () => {
-    if (typeof window === 'undefined' || !event) {
+    if (typeof window === 'undefined') {
       return;
     }
 
@@ -148,8 +156,7 @@ const ViewEvent: React.FC<ViewEventProps> = ({ events, addRsvp, isAdmin }) => {
     const hash = url.hash || '';
     const [hashPath, existingQuery = ''] = hash.split('?');
     const params = new URLSearchParams(existingQuery);
-    const shareToken = event.shareToken ?? event.id;
-    params.set('guest', shareToken);
+    params.set('guest', shareToken || event.shareToken);
     url.hash = `${hashPath}?${params.toString()}`;
     url.search = '';
     const shareUrl = url.toString();
@@ -177,18 +184,6 @@ const ViewEvent: React.FC<ViewEventProps> = ({ events, addRsvp, isAdmin }) => {
     }, 2000);
   };
 
-  if (!event) {
-    return (
-      <div className="text-center p-10">
-        <h2 className="text-2xl font-bold text-slate-700">Event Not Found</h2>
-        <p className="text-slate-500 mt-2">The link may be incorrect. Please check with the host.</p>
-        <Link to="/" className="mt-6 inline-block bg-primary text-white font-bold py-2 px-4 rounded-lg hover:bg-primary-700 transition">
-          Create a New Event
-        </Link>
-      </div>
-    );
-  }
-
   const attendingGuests = event.guests.filter(g => g.status === 'attending');
   const totalGuests = attendingGuests.reduce((sum, guest) => sum + 1 + guest.plusOnes, 0);
 
@@ -199,371 +194,354 @@ const ViewEvent: React.FC<ViewEventProps> = ({ events, addRsvp, isAdmin }) => {
       month: 'long',
       day: 'numeric',
       hour: 'numeric',
-      minute: 'numeric',
+      minute: '2-digit',
     });
-  const formatTime = (dateString: string) =>
-    new Date(dateString).toLocaleString('en-US', { hour: 'numeric', minute: 'numeric', hour12: true });
 
-  const formattedStartDate = formatDateTime(event.date);
-  const formattedEndDate = event.endDate ? formatDateTime(event.endDate) : null;
-  const sameDay = event.endDate && new Date(event.date).toDateString() === new Date(event.endDate).toDateString();
-  const showHeroControls = heroImages.length > 1;
-  const showEditButton = isAdmin;
-  const showShareButton = isAdmin || event.allowShareLink !== false;
-  const hasActionButtons = showEditButton || showShareButton;
-  const hasAddress = isLikelyAddress(event.location);
-  const directionsLink = `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(event.location)}`;
+  const formatDateRange = () => {
+    const start = event.date ? new Date(event.date) : null;
+    const end = event.endDate ? new Date(event.endDate) : null;
 
-  const handlePreviousSlide = () => {
-    setCurrentSlide(prev => (prev === 0 ? heroImages.length - 1 : prev - 1));
+    if (!start || Number.isNaN(start.getTime())) {
+      return 'Date not set';
+    }
+
+    if (!end || Number.isNaN(end.getTime())) {
+      return formatDateTime(event.date);
+    }
+
+    const sameDay = start.toDateString() === end.toDateString();
+    if (sameDay) {
+      return `${start.toLocaleDateString('en-US', { dateStyle: 'medium' })}, ${start.toLocaleTimeString('en-US', {
+        hour: 'numeric',
+        minute: '2-digit',
+      })} - ${end.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' })}`;
+    }
+
+    return `${start.toLocaleString('en-US', { dateStyle: 'medium', timeStyle: 'short' })} → ${end.toLocaleString('en-US', {
+      dateStyle: 'medium',
+      timeStyle: 'short',
+    })}`;
   };
 
-  const handleNextSlide = () => {
-    setCurrentSlide(prev => (prev === heroImages.length - 1 ? 0 : prev + 1));
+  const renderHeroNavigation = () => {
+    if (heroImages.length <= 1) {
+      return null;
+    }
+
+    const total = heroImages.length;
+    const goTo = (index: number) => {
+      const nextIndex = (index + total) % total;
+      setCurrentSlide(nextIndex);
+    };
+
+    return (
+      <div className="absolute inset-0 flex items-center justify-between p-4">
+        <button
+          type="button"
+          onClick={() => goTo(currentSlide - 1)}
+          className="bg-white/70 text-slate-700 rounded-full p-2 hover:bg-white focus:outline-none focus:ring-2 focus:ring-primary"
+          aria-label="Previous image"
+        >
+          <ChevronLeftIcon className="h-6 w-6" />
+        </button>
+        <button
+          type="button"
+          onClick={() => goTo(currentSlide + 1)}
+          className="bg-white/70 text-slate-700 rounded-full p-2 hover:bg-white focus:outline-none focus:ring-2 focus:ring-primary"
+          aria-label="Next image"
+        >
+          <ChevronRightIcon className="h-6 w-6" />
+        </button>
+      </div>
+    );
   };
 
   return (
-    <>
-      <style>{`
-        .prose h1, .prose h2, .prose h3, .prose h4, .prose h5, .prose h6 { margin-top: 1.2em; margin-bottom: 0.5em; font-weight: 600; color: ${theme.text}; }
-        .prose h1 { font-size: 1.875rem; }
-        .prose h2 { font-size: 1.5rem; }
-        .prose h3 { font-size: 1.25rem; }
-        .prose p { margin-bottom: 1em; color: ${mutedTextColor}; }
-        .prose ul, .prose ol { margin-left: 1.5em; margin-bottom: 1em; color: ${mutedTextColor}; }
-        .prose ul { list-style-type: disc; }
-        .prose ol { list-style-type: decimal; }
-        .prose a { color: ${theme.primary}; text-decoration: underline; }
-        .prose strong { font-weight: 600; color: ${theme.text}; }
-        .prose blockquote { border-left: 4px solid ${dividerColor}; padding-left: 1em; margin-left: 0; font-style: italic; color: ${mutedTextColor}; }
-        .prose code { background-color: ${softPrimary}; padding: 0.2em 0.4em; margin: 0; font-size: 85%; border-radius: 3px; font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace; }
-        .prose pre { background-color: ${softPrimary}; padding: 1em; border-radius: 0.5em; overflow-x: auto; }
-      `}</style>
-      <div style={backgroundStyle} className="py-10">
-        <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="grid grid-cols-1 lg:grid-cols-5 gap-8">
-            <div className="lg:col-span-3">
-              <div className={`rounded-2xl shadow-2xl shadow-slate-200 p-8 ${event.backgroundImage ? 'bg-white/85 backdrop-blur-md' : 'bg-white'}`}>
-                {heroImages.length > 0 && (
-                  <div className="mb-6">
-                    <div className="relative overflow-hidden rounded-2xl shadow-lg">
-                      <img
-                        src={heroImages[currentSlide]}
-                        alt={`Event highlight ${currentSlide + 1}`}
-                        className="w-full h-64 object-cover"
-                      />
-                      {showHeroControls && (
-                        <>
-                          <button
-                            type="button"
-                            onClick={handlePreviousSlide}
-                            className="absolute left-4 top-1/2 -translate-y-1/2 rounded-full p-2 shadow-lg focus:outline-none hover:opacity-90 transition"
-                            style={{ backgroundColor: theme.primary, color: '#fff' }}
-                            aria-label="Previous photo"
-                          >
-                            <ChevronLeftIcon className="h-5 w-5" />
-                          </button>
-                          <button
-                            type="button"
-                            onClick={handleNextSlide}
-                            className="absolute right-4 top-1/2 -translate-y-1/2 rounded-full p-2 shadow-lg focus:outline-none hover:opacity-90 transition"
-                            style={{ backgroundColor: theme.primary, color: '#fff' }}
-                            aria-label="Next photo"
-                          >
-                            <ChevronRightIcon className="h-5 w-5" />
-                          </button>
-                          <div className="absolute bottom-3 left-1/2 -translate-x-1/2 flex items-center gap-2">
-                            {heroImages.map((_, index) => (
-                              <button
-                                key={index}
-                                type="button"
-                                onClick={() => setCurrentSlide(index)}
-                                className="h-2.5 w-2.5 rounded-full transition"
-                                style={{
-                                  backgroundColor: index === currentSlide ? theme.primary : softPrimary,
-                                  border: index === currentSlide ? `1px solid ${theme.primary}` : '1px solid transparent',
-                                }}
-                                aria-label={`Show photo ${index + 1}`}
-                              />
-                            ))}
-                          </div>
-                        </>
-                      )}
-                    </div>
-                  </div>
-                )}
-
-                <div className="mb-6">
-                  <p className="text-base font-semibold uppercase tracking-wide" style={{ color: theme.primary }}>
-                    You're Invited
-                  </p>
-                  <h1 className="text-4xl sm:text-5xl font-extrabold" style={{ color: theme.text }}>
-                    {event.title}
-                  </h1>
-                  <p className="mt-4 text-xl" style={{ color: mutedTextColor }}>
-                    Hosted by {event.host}
-                  </p>
-                </div>
-
-                <div className="space-y-4 pt-6 border-t" style={{ borderColor: dividerColor, color: theme.text }}>
-                  <div className="flex items-start">
-                    <CalendarIcon className="h-6 w-6 mr-4 mt-1 flex-shrink-0" style={{ color: theme.primary }} />
-                    <span className="text-lg" style={{ color: mutedTextColor }}>
-                      {formattedEndDate
-                        ? sameDay
-                          ? `${new Date(event.date).toLocaleDateString('en-US', { weekday: 'long', month: 'long', day: 'numeric' })}, ${formatTime(event.date)} - ${formatTime(event.endDate)}`
-                          : `From ${formattedStartDate} to ${formattedEndDate}`
-                        : formattedStartDate}
-                    </span>
-                  </div>
-                  <div className="flex items-start">
-                    <LocationIcon className="h-6 w-6 mr-4 mt-1 flex-shrink-0" style={{ color: theme.primary }} />
-                    <div className="text-lg flex items-center gap-2 flex-wrap" style={{ color: mutedTextColor }}>
-                      <span>{event.location}</span>
-                      {hasAddress && (
-                        <a
-                          href={directionsLink}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="inline-flex items-center justify-center rounded-full p-1.5 transition hover:bg-slate-200/60"
-                          style={{ color: theme.primary }}
-                          aria-label="Open directions in Google Maps"
-                          title="Open in Google Maps"
-                        >
-                          <DirectionsIcon className="h-5 w-5" />
-                        </a>
-                      )}
-                    </div>
+    <div className="min-h-screen" style={backgroundStyle}>
+      <div className="max-w-5xl mx-auto px-4 py-10 space-y-6">
+        <header className="bg-white/90 backdrop-blur rounded-3xl shadow-xl p-8">
+          <div className="flex flex-col gap-6 md:flex-row md:justify-between md:items-start">
+            <div className="space-y-4">
+              <div className="inline-flex items-center gap-2 bg-primary/10 text-primary px-4 py-1 rounded-full text-sm font-semibold">
+                Hosted by {event.host}
+              </div>
+              <h1 className="text-4xl font-extrabold text-slate-800 tracking-tight">{event.title}</h1>
+              <div className="space-y-3 text-sm text-slate-600">
+                <div className="flex items-start gap-3">
+                  <CalendarIcon className="h-5 w-5 text-primary mt-0.5" />
+                  <div>
+                    <p className="font-semibold text-slate-800">When</p>
+                    <p>{formatDateRange()}</p>
                   </div>
                 </div>
-
-                {event.message && (
-                  <div className="mt-6 border-t pt-6" style={{ borderColor: dividerColor }}>
-                    <div className="prose max-w-none">
-                      <ReactMarkdown remarkPlugins={[remarkGfm]}>{event.message}</ReactMarkdown>
-                    </div>
-                  </div>
-                )}
-                {hasActionButtons && (
-                  <div className="mt-8 border-t pt-6 flex flex-col sm:flex-row gap-4" style={{ borderColor: dividerColor }}>
-                    {showEditButton && (
-                      <Link
-                        to={`/event/${event.id}/edit`}
-                        className="flex-1 flex items-center justify-center gap-2 font-bold py-3 px-4 rounded-lg hover:opacity-90 focus:outline-none focus-visible:ring-4 focus-visible:ring-offset-2"
-                        style={{ backgroundColor: theme.primary, color: '#fff' }}
+                <div className="flex items-start gap-3">
+                  <LocationIcon className="h-5 w-5 text-primary mt-0.5" />
+                  <div>
+                    <p className="font-semibold text-slate-800">Where</p>
+                    <p>{event.location}</p>
+                    {isLikelyAddress(event.location) && (
+                      <a
+                        href={`https://maps.google.com/?q=${encodeURIComponent(event.location)}`}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="inline-flex items-center gap-2 text-primary hover:text-primary-700 mt-1"
                       >
-                        <PencilIcon className="h-5 w-5" /> Edit Event
-                      </Link>
-                    )}
-                    {showShareButton && (
-                      <button
-                        onClick={handleCopyLink}
-                        className="flex-1 flex items-center justify-center gap-2 font-bold py-3 px-4 rounded-lg hover:opacity-95 focus:outline-none focus-visible:ring-4 focus-visible:ring-offset-2"
-                        style={{ backgroundColor: softPrimary, color: theme.text }}
-                      >
-                        {linkCopied ? (
-                          <>
-                            <CheckCircleIcon className="h-5 w-5" style={{ color: theme.primary }} /> Link Copied!
-                          </>
-                        ) : (
-                          <>
-                            <ClipboardIcon className="h-5 w-5" /> Copy Shareable Link
-                          </>
-                        )}
-                      </button>
+                        <DirectionsIcon className="h-4 w-4" />
+                        Get directions
+                      </a>
                     )}
                   </div>
-                )}
+                </div>
+                <div className="flex items-start gap-3">
+                  <UsersIcon className="h-5 w-5 text-primary mt-0.5" />
+                  <div>
+                    <p className="font-semibold text-slate-800">Guest list</p>
+                    <p>
+                      {totalGuests} attending
+                      {event.showGuestList ? ' • visible to everyone' : ' • hidden from attendees'}
+                    </p>
+                  </div>
+                </div>
               </div>
             </div>
-
-            <div className="lg:col-span-2 space-y-8">
-              <div className={`rounded-2xl shadow-2xl shadow-slate-200 p-8 ${event.backgroundImage ? 'bg-white/85 backdrop-blur-md' : 'bg-white'}`}>
-                <h2 className="text-2xl font-bold mb-4" style={{ color: theme.text }}>
-                  Are you coming?
-                </h2>
-                {submitted ? (
-                  <div className="text-center bg-green-50 p-6 rounded-lg">
-                    <CheckCircleIcon className="h-12 w-12 text-green-500 mx-auto" />
-                    <p className="mt-4 font-semibold text-green-800 text-lg">Thanks for your RSVP!</p>
-                    <p className="text-green-700">We've saved your response.</p>
-                  </div>
-                ) : rsvpChoice ? (
-                  <form onSubmit={handleRsvpSubmit} className="space-y-4">
-                    {rsvpChoice === 'yes' ? (
-                      <>
-                        <div>
-                          <label htmlFor="name" className="text-sm font-semibold" style={{ color: theme.text }}>
-                            Your Name
-                          </label>
-                          <input
-                            id="name"
-                            type="text"
-                            value={name}
-                            onChange={(e) => setName(e.target.value)}
-                            required
-                            className="w-full mt-1 px-4 py-2 border border-slate-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary transition"
-                          />
-                        </div>
-                        <div>
-                          <label htmlFor="plusOnes" className="text-sm font-semibold" style={{ color: theme.text }}>
-                            Guests you're bringing
-                          </label>
-                          <input
-                            id="plusOnes"
-                            type="number"
-                            value={plusOnes}
-                            onChange={(e) => {
-                              const parsed = Number(e.target.value);
-                              setPlusOnes(Number.isNaN(parsed) ? 0 : Math.max(0, parsed));
-                            }}
-                            min="0"
-                            className="w-full mt-1 px-4 py-2 border border-slate-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary transition"
-                          />
-                        </div>
-                        <div>
-                          <label htmlFor="email" className="text-sm font-semibold" style={{ color: theme.text }}>
-                            Email (Optional)
-                          </label>
-                          <input
-                            id="email"
-                            type="email"
-                            value={email}
-                            onChange={(e) => setEmail(e.target.value)}
-                            placeholder="For event updates"
-                            className="w-full mt-1 px-4 py-2 border border-slate-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary transition"
-                          />
-                        </div>
-                        <div>
-                          <label htmlFor="comment" className="text-sm font-semibold" style={{ color: theme.text }}>
-                            Comment (Optional)
-                          </label>
-                          <textarea
-                            id="comment"
-                            value={comment}
-                            onChange={(e) => setComment(e.target.value)}
-                            rows={2}
-                            className="w-full mt-1 px-4 py-2 border border-slate-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary transition"
-                          ></textarea>
-                        </div>
-                      </>
-                    ) : (
-                      <>
-                        <p className="text-sm mb-4" style={{ color: subtleTextColor }}>
-                          Sorry you can't make it. Thanks for letting the host know!
-                        </p>
-                        <div>
-                          <label htmlFor="name" className="text-sm font-semibold" style={{ color: theme.text }}>
-                            Your Name
-                          </label>
-                          <input
-                            id="name"
-                            type="text"
-                            value={name}
-                            onChange={(e) => setName(e.target.value)}
-                            required
-                            className="w-full mt-1 px-4 py-2 border border-slate-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary transition"
-                          />
-                        </div>
-                        <div>
-                          <label htmlFor="comment" className="text-sm font-semibold" style={{ color: theme.text }}>
-                            Reason (Optional)
-                          </label>
-                          <textarea
-                            id="comment"
-                            value={comment}
-                            onChange={(e) => setComment(e.target.value)}
-                            rows={2}
-                            placeholder="Let the host know why you can't attend."
-                            className="w-full mt-1 px-4 py-2 border border-slate-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary transition"
-                          ></textarea>
-                        </div>
-                      </>
-                    )}
-                    <button
-                      type="submit"
-                      className="w-full font-bold py-3 px-4 rounded-lg hover:opacity-90 focus:outline-none focus-visible:ring-4 focus-visible:ring-offset-2"
-                      style={{ backgroundColor: theme.primary, color: '#fff' }}
-                    >
-                      Submit RSVP
-                    </button>
-                    <button
-                      type="button"
-                      onClick={() => setRsvpChoice(null)}
-                      className="w-full text-center text-sm mt-2"
-                      style={{ color: theme.primary }}
-                    >
-                      Change response
-                    </button>
-                  </form>
-                ) : (
-                  <div className="flex flex-col sm:flex-row gap-4">
-                    <button
-                      onClick={() => {
-                        setSubmitted(false);
-                        setRsvpChoice('yes');
-                      }}
-                      className="w-full bg-green-500 text-white font-bold py-3 px-4 rounded-lg hover:bg-green-600 focus:outline-none focus:ring-4 focus:ring-green-300 transition-all duration-300"
-                    >
-                      Yes, I'm coming
-                    </button>
-                    <button
-                      onClick={() => {
-                        setSubmitted(false);
-                        setRsvpChoice('no');
-                      }}
-                      className="w-full bg-slate-600 text-white font-bold py-3 px-4 rounded-lg hover:bg-slate-700 focus:outline-none focus:ring-4 focus:ring-slate-300 transition-all duration-300"
-                    >
-                      No, can't make it
-                    </button>
-                  </div>
-                )}
-              </div>
-
-              <div className={`rounded-2xl shadow-2xl shadow-slate-200 p-8 ${event.backgroundImage ? 'bg-white/85 backdrop-blur-md' : 'bg-white'}`}>
-                <div className="flex items-center gap-3 mb-4">
-                  <UsersIcon className="h-7 w-7" style={{ color: theme.primary }} />
-                  <h2 className="text-2xl font-bold" style={{ color: theme.text }}>
-                    {totalGuests} {totalGuests === 1 ? 'Guest' : 'Guests'} Attending
-                  </h2>
-                </div>
-                {event.showGuestList ? (
-                  <ul className="space-y-3 max-h-60 overflow-y-auto pr-2">
-                    {attendingGuests.length > 0 ? (
-                      attendingGuests.map(guest => (
-                        <li key={guest.id} className="p-3 rounded-lg" style={{ backgroundColor: softPrimary }}>
-                          <div className="font-semibold flex items-center gap-2" style={{ color: theme.text }}>
-                            <UserIcon className="h-5 w-5" style={{ color: subtleTextColor }} />
-                            {guest.name}{' '}
-                            {guest.plusOnes > 0 && (
-                              <span
-                                className="text-xs font-normal rounded-full px-2 py-0.5"
-                                style={{ backgroundColor: hexToRgba(theme.primary, 0.18), color: theme.primary }}
-                              >
-                                +{guest.plusOnes}
-                              </span>
-                            )}
-                          </div>
-                          {guest.comment && (
-                            <p className="text-sm italic mt-1 ml-7" style={{ color: subtleTextColor }}>
-                              "{guest.comment}"
-                            </p>
-                          )}
-                        </li>
-                      ))
-                    ) : (
-                      <p style={{ color: subtleTextColor }}>Be the first to RSVP!</p>
-                    )}
-                  </ul>
-                ) : (
-                  <p style={{ color: subtleTextColor }}>The host has chosen to keep the guest list private.</p>
-                )}
-              </div>
-            </div>
+            {isAdmin && (
+              <Link
+                to={`/event/${event.id}/edit`}
+                className="inline-flex items-center gap-2 bg-primary text-white font-semibold px-5 py-3 rounded-xl hover:bg-primary-700 transition"
+              >
+                <PencilIcon className="h-4 w-4" /> Edit Event
+              </Link>
+            )}
           </div>
-        </div>
+        </header>
+
+        {heroImages.length > 0 && (
+          <section className="relative rounded-3xl overflow-hidden shadow-xl">
+            <img
+              src={heroImages[currentSlide]}
+              alt="Event highlight"
+              className="w-full h-80 object-cover"
+            />
+            {renderHeroNavigation()}
+            <div className="absolute bottom-4 left-1/2 -translate-x-1/2 flex gap-2">
+              {heroImages.map((_, index) => (
+                <span
+                  key={index}
+                  className={`h-2.5 w-2.5 rounded-full transition ${index === currentSlide ? 'bg-white' : 'bg-white/40'}`}
+                />
+              ))}
+            </div>
+          </section>
+        )}
+
+        <section className="grid gap-6 md:grid-cols-[1.1fr_0.9fr]">
+          <article className="bg-white/95 backdrop-blur rounded-3xl shadow-xl p-8 space-y-6">
+            <h2 className="text-2xl font-bold text-slate-800">About this celebration</h2>
+            <ReactMarkdown
+              remarkPlugins={[remarkGfm]}
+              className="prose prose-slate max-w-none"
+              components={{
+                a: props => (
+                  <a {...props} className="text-primary hover:text-primary-700" target="_blank" rel="noreferrer" />
+                ),
+                h1: props => <h2 {...props} className="text-2xl" />,
+                h2: props => <h3 {...props} className="text-xl" />,
+              }}
+            >
+              {event.message || 'Details coming soon!'}
+            </ReactMarkdown>
+          </article>
+
+          <aside className="space-y-6">
+            <div className="bg-white/95 backdrop-blur rounded-3xl shadow-xl p-6 space-y-6">
+              <header>
+                <h3 className="text-lg font-semibold text-slate-800">Your RSVP</h3>
+                <p className="text-sm text-slate-500">Let the host know if they should save you a slice of cake.</p>
+              </header>
+
+              <div className="grid grid-cols-2 gap-3">
+                <button
+                  type="button"
+                  onClick={() => setRsvpChoice('yes')}
+                  className={`rounded-xl border-2 py-3 font-semibold transition ${
+                    rsvpChoice === 'yes'
+                      ? 'border-primary bg-primary/10 text-primary'
+                      : 'border-slate-200 text-slate-600 hover:border-primary/50'
+                  }`}
+                >
+                  Count me in!
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setRsvpChoice('no')}
+                  className={`rounded-xl border-2 py-3 font-semibold transition ${
+                    rsvpChoice === 'no'
+                      ? 'border-slate-400 bg-slate-100 text-slate-600'
+                      : 'border-slate-200 text-slate-600 hover:border-slate-400'
+                  }`}
+                >
+                  Can’t make it
+                </button>
+              </div>
+
+              <form onSubmit={handleRsvpSubmit} className="space-y-4">
+                <div className="space-y-1.5">
+                  <label htmlFor="guest-name" className="text-sm font-semibold text-slate-700">
+                    Your name
+                  </label>
+                  <input
+                    id="guest-name"
+                    type="text"
+                    value={name}
+                    onChange={event => setName(event.target.value)}
+                    placeholder="Jane Doe"
+                    className="w-full rounded-xl border border-slate-200 px-4 py-2 focus:border-primary focus:ring-2 focus:ring-primary/40"
+                    required
+                  />
+                </div>
+
+                {rsvpChoice === 'yes' && (
+                  <div className="space-y-1.5">
+                    <label htmlFor="guest-email" className="text-sm font-semibold text-slate-700">
+                      Email (optional)
+                    </label>
+                    <input
+                      id="guest-email"
+                      type="email"
+                      value={email}
+                      onChange={event => setEmail(event.target.value)}
+                      placeholder="you@example.com"
+                      className="w-full rounded-xl border border-slate-200 px-4 py-2 focus:border-primary focus:ring-2 focus:ring-primary/40"
+                    />
+                  </div>
+                )}
+
+                {rsvpChoice === 'yes' && (
+                  <div className="space-y-1.5">
+                    <label htmlFor="guest-plus-ones" className="text-sm font-semibold text-slate-700">
+                      Bringing friends?
+                    </label>
+                    <input
+                      id="guest-plus-ones"
+                      type="number"
+                      min={0}
+                      value={plusOnes}
+                      onChange={event => setPlusOnes(Number.parseInt(event.target.value, 10) || 0)}
+                      className="w-full rounded-xl border border-slate-200 px-4 py-2 focus:border-primary focus:ring-2 focus:ring-primary/40"
+                    />
+                  </div>
+                )}
+
+                <div className="space-y-1.5">
+                  <label htmlFor="guest-comment" className="text-sm font-semibold text-slate-700">
+                    Message for the host
+                  </label>
+                  <textarea
+                    id="guest-comment"
+                    value={comment}
+                    onChange={event => setComment(event.target.value)}
+                    rows={3}
+                    placeholder="Add a note, song request, or dietary need."
+                    className="w-full rounded-xl border border-slate-200 px-4 py-2 focus:border-primary focus:ring-2 focus:ring-primary/40"
+                  />
+                </div>
+
+                <button
+                  type="submit"
+                  disabled={!rsvpChoice || isSubmitting}
+                  className="w-full rounded-xl bg-primary text-white font-semibold py-3 hover:bg-primary-700 transition disabled:opacity-60 disabled:cursor-not-allowed"
+                >
+                  {isSubmitting ? 'Sending…' : 'Send RSVP'}
+                </button>
+
+                {submitted && (
+                  <p className="text-sm text-green-600 flex items-center gap-2">
+                    <CheckCircleIcon className="h-4 w-4" /> Thanks! We’ve saved your response.
+                  </p>
+                )}
+              </form>
+
+              <div className="border-t border-slate-200 pt-4 text-xs text-slate-500">
+                {event.passwordProtected ? (
+                  <p>This invitation is private. Keep the password and link handy to update your RSVP later.</p>
+                ) : (
+                  <p>Share the link below if you want friends to RSVP too.</p>
+                )}
+              </div>
+            </div>
+
+            <div className="bg-white/95 backdrop-blur rounded-3xl shadow-xl p-6 space-y-4">
+              <div className="flex items-center justify-between">
+                <h3 className="text-lg font-semibold text-slate-800">Share this invitation</h3>
+                <ClipboardIcon className="h-5 w-5 text-primary" />
+              </div>
+              <p className="text-sm text-slate-500">
+                {event.allowShareLink
+                  ? 'Copy the link to send this invite to friends and family.'
+                  : 'The host disabled public sharing for this invite.'}
+              </p>
+              <button
+                type="button"
+                onClick={handleCopyLink}
+                disabled={!event.allowShareLink}
+                className="w-full rounded-xl bg-slate-900 text-white font-semibold py-3 hover:bg-slate-700 transition disabled:opacity-40 disabled:cursor-not-allowed"
+              >
+                {linkCopied ? 'Link copied!' : 'Copy invitation link'}
+              </button>
+            </div>
+          </aside>
+        </section>
+
+        {event.showGuestList && (
+          <section className="bg-white/95 backdrop-blur rounded-3xl shadow-xl p-8 space-y-6">
+            <header className="flex items-center justify-between">
+              <div>
+                <h2 className="text-2xl font-bold text-slate-800">Guest list</h2>
+                <p className="text-sm text-slate-500">See who’s coming along for the fun.</p>
+              </div>
+              <span className="inline-flex items-center gap-2 text-sm font-semibold text-slate-600 bg-slate-100 px-3 py-1 rounded-full">
+                <UserIcon className="h-4 w-4 text-primary" /> {attendingGuests.length} RSVPs
+              </span>
+            </header>
+            {attendingGuests.length === 0 ? (
+              <p className="text-slate-500 text-sm">No one has RSVP’d yet. Be the first to respond!</p>
+            ) : (
+              <ul className="grid gap-3 sm:grid-cols-2">
+                {attendingGuests.map(guest => (
+                  <li
+                    key={guest.id}
+                    className="rounded-2xl border border-slate-200 bg-white/80 px-4 py-3 flex flex-col gap-1"
+                  >
+                    <div className="flex items-center justify-between">
+                      <p className="font-semibold text-slate-800">{guest.name}</p>
+                      <span className="text-xs text-slate-400">
+                        {guest.respondedAt
+                          ? new Date(guest.respondedAt).toLocaleDateString('en-US', {
+                              month: 'short',
+                              day: 'numeric',
+                            })
+                          : '—'}
+                      </span>
+                    </div>
+                    <p className="text-xs text-slate-500">
+                      {guest.plusOnes > 0 ? `Attending +${guest.plusOnes}` : 'Attending'}
+                    </p>
+                    {guest.comment && <p className="text-sm text-slate-600">“{guest.comment}”</p>}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </section>
+        )}
+
+        <footer className="text-center text-xs text-slate-400 pb-8">
+          <p>
+            Need to change your RSVP? Revisit this page with the same link
+            {event.passwordProtected && ' and password'}.
+          </p>
+        </footer>
       </div>
-    </>
+    </div>
   );
 };
 

--- a/contexts/AdminContext.tsx
+++ b/contexts/AdminContext.tsx
@@ -1,0 +1,110 @@
+import React from 'react';
+import type { Event } from '../types';
+import { fetchAdminEvents } from '../lib/api';
+
+const ADMIN_TOKEN_STORAGE_KEY = 'party-inviter-admin-token';
+
+interface AdminContextValue {
+  token: string | null;
+  isAdmin: boolean;
+  events: Event[];
+  isLoadingEvents: boolean;
+  setEvents: React.Dispatch<React.SetStateAction<Event[]>>;
+  setToken: (token: string | null) => void;
+  refreshEvents: () => Promise<void>;
+  clearSession: () => void;
+}
+
+const AdminContext = React.createContext<AdminContextValue | undefined>(undefined);
+
+const readInitialToken = () => {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  try {
+    return window.localStorage.getItem(ADMIN_TOKEN_STORAGE_KEY);
+  } catch (error) {
+    console.error('Unable to read admin token from storage:', error);
+    return null;
+  }
+};
+
+export const AdminProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [token, setTokenState] = React.useState<string | null>(readInitialToken);
+  const [events, setEvents] = React.useState<Event[]>([]);
+  const [isLoadingEvents, setIsLoadingEvents] = React.useState(false);
+
+  const persistToken = React.useCallback((value: string | null) => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+    try {
+      if (value) {
+        window.localStorage.setItem(ADMIN_TOKEN_STORAGE_KEY, value);
+      } else {
+        window.localStorage.removeItem(ADMIN_TOKEN_STORAGE_KEY);
+      }
+    } catch (error) {
+      console.error('Unable to persist admin token:', error);
+    }
+  }, []);
+
+  const setToken = React.useCallback(
+    (value: string | null) => {
+      setTokenState(value);
+      persistToken(value);
+    },
+    [persistToken],
+  );
+
+  const clearSession = React.useCallback(() => {
+    setToken(null);
+    setEvents([]);
+  }, [setToken]);
+
+  const refreshEvents = React.useCallback(async () => {
+    if (!token) {
+      setEvents([]);
+      return;
+    }
+
+    setIsLoadingEvents(true);
+    try {
+      const fetched = await fetchAdminEvents(token);
+      setEvents(fetched);
+    } catch (error) {
+      console.error('Unable to fetch events:', error);
+      clearSession();
+    } finally {
+      setIsLoadingEvents(false);
+    }
+  }, [token, clearSession]);
+
+  React.useEffect(() => {
+    if (token) {
+      refreshEvents();
+    }
+  }, [token, refreshEvents]);
+
+  const contextValue = React.useMemo<AdminContextValue>(() => ({
+    token,
+    isAdmin: Boolean(token),
+    events,
+    setEvents,
+    setToken,
+    refreshEvents,
+    isLoadingEvents,
+    clearSession,
+  }), [token, events, setToken, refreshEvents, isLoadingEvents, clearSession]);
+
+  return <AdminContext.Provider value={contextValue}>{children}</AdminContext.Provider>;
+};
+
+export const useAdminContext = () => {
+  const ctx = React.useContext(AdminContext);
+  if (!ctx) {
+    throw new Error('useAdminContext must be used within an AdminProvider');
+  }
+  return ctx;
+};

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -1,0 +1,223 @@
+import type { Event, EventTheme, Guest } from '../types';
+
+const API_BASE_URL = (import.meta.env.VITE_API_BASE_URL || '').replace(/\/$/, '');
+
+interface ApiEvent {
+  id: string;
+  title: string;
+  host: string;
+  date: string;
+  endDate?: string | null;
+  location: string;
+  message: string;
+  showGuestList: boolean;
+  passwordProtected: boolean;
+  allowShareLink: boolean;
+  shareToken: string;
+  theme?: EventTheme | null;
+  backgroundImage?: string | null;
+  heroImages?: string[] | null;
+  guests: Guest[];
+}
+
+export interface EventPayload {
+  title: string;
+  host: string;
+  date: string;
+  endDate?: string | null;
+  location: string;
+  message: string;
+  showGuestList: boolean;
+  allowShareLink: boolean;
+  password?: string | null;
+  removePassword?: boolean;
+  theme?: EventTheme;
+  backgroundImage?: string | null;
+  heroImages?: string[];
+}
+
+export interface AccessResultAdmin {
+  type: 'admin';
+  token: string;
+}
+
+export interface AccessResultEvent {
+  type: 'event';
+  eventId: string;
+  shareToken: string;
+  guestToken?: string;
+}
+
+export type AccessResult = AccessResultAdmin | AccessResultEvent;
+
+interface RequestOptions extends RequestInit {
+  token?: string | null;
+}
+
+const withHeaders = (options: RequestOptions = {}): RequestInit => {
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+  };
+
+  if (options.headers) {
+    const existing = options.headers as Record<string, string>;
+    Object.keys(existing).forEach(key => {
+      headers[key] = existing[key];
+    });
+  }
+
+  if (options.token) {
+    headers.Authorization = `Bearer ${options.token}`;
+  }
+
+  return {
+    ...options,
+    headers,
+  };
+};
+
+const request = async <T>(path: string, options: RequestOptions = {}): Promise<T> => {
+  if (!API_BASE_URL) {
+    throw new Error('API base URL is not configured. Set VITE_API_BASE_URL in your environment.');
+  }
+
+  const response = await fetch(`${API_BASE_URL}${path}`, withHeaders(options));
+  const text = await response.text();
+  const data = text ? JSON.parse(text) : null;
+
+  if (!response.ok) {
+    const error = new Error(data?.message || 'Request failed');
+    (error as Error & { status?: number; payload?: unknown }).status = response.status;
+    (error as Error & { status?: number; payload?: unknown }).payload = data;
+    throw error;
+  }
+
+  return data as T;
+};
+
+const mapEvent = (apiEvent: ApiEvent): Event => ({
+  id: apiEvent.id,
+  title: apiEvent.title,
+  host: apiEvent.host,
+  date: apiEvent.date,
+  endDate: apiEvent.endDate ?? undefined,
+  location: apiEvent.location,
+  message: apiEvent.message,
+  showGuestList: apiEvent.showGuestList,
+  allowShareLink: apiEvent.allowShareLink,
+  passwordProtected: apiEvent.passwordProtected,
+  shareToken: apiEvent.shareToken,
+  theme: apiEvent.theme ?? undefined,
+  backgroundImage: apiEvent.backgroundImage ?? undefined,
+  heroImages: apiEvent.heroImages ?? undefined,
+  guests: apiEvent.guests || [],
+});
+
+export const submitAccessPassword = (password: string) =>
+  request<AccessResult>('/api/access', {
+    method: 'POST',
+    body: JSON.stringify({ password }),
+  });
+
+export const fetchAdminEvents = async (token: string): Promise<Event[]> => {
+  const events = await request<ApiEvent[]>('/api/admin/events', { token });
+  return events.map(mapEvent);
+};
+
+export const createEvent = async (token: string, payload: EventPayload): Promise<Event> => {
+  const event = await request<ApiEvent>('/api/admin/events', {
+    method: 'POST',
+    body: JSON.stringify(payload),
+    token,
+  });
+  return mapEvent(event);
+};
+
+export const updateEvent = async (token: string, eventId: string, payload: EventPayload): Promise<Event> => {
+  const event = await request<ApiEvent>(`/api/admin/events/${eventId}`, {
+    method: 'PUT',
+    body: JSON.stringify(payload),
+    token,
+  });
+  return mapEvent(event);
+};
+
+export const deleteEvent = (token: string, eventId: string) =>
+  request<void>(`/api/admin/events/${eventId}`, {
+    method: 'DELETE',
+    token,
+  });
+
+interface PublicEventResponse {
+  event?: ApiEvent;
+  requiresPassword?: boolean;
+}
+
+export const fetchPublicEvent = async (
+  shareToken: string,
+  guestToken?: string | null,
+): Promise<{ event: Event | null; requiresPassword: boolean }> => {
+  try {
+    const response = await request<PublicEventResponse>(`/api/public/events/${shareToken}`, {
+      headers: guestToken ? { Authorization: `Bearer ${guestToken}` } : undefined,
+    });
+
+    if (response.event) {
+      return { event: mapEvent(response.event), requiresPassword: false };
+    }
+
+    return { event: null, requiresPassword: Boolean(response.requiresPassword) };
+  } catch (error) {
+    const status = (error as Error & { status?: number; payload?: PublicEventResponse }).status;
+    const payload = (error as Error & { status?: number; payload?: PublicEventResponse }).payload;
+    if (status === 401 && payload?.requiresPassword) {
+      return { event: null, requiresPassword: true };
+    }
+    throw error;
+  }
+};
+
+export const authorizeEventAccess = (shareToken: string, password: string) =>
+  request<{ guestToken: string; eventId: string }>(`/api/public/events/${shareToken}/access`, {
+    method: 'POST',
+    body: JSON.stringify({ password }),
+  });
+
+export interface RsvpPayload {
+  name: string;
+  plusOnes: number;
+  comment: string;
+  email?: string;
+  status: 'attending' | 'not-attending';
+}
+
+interface RsvpResponse {
+  event: ApiEvent;
+  guest: Guest;
+  guestToken?: string;
+  manageToken?: string;
+}
+
+export const submitRsvp = async (
+  shareToken: string,
+  payload: RsvpPayload,
+  guestToken?: string | null,
+  manageToken?: string | null,
+) => {
+  const response = await request<RsvpResponse>(`/api/public/events/${shareToken}/rsvps`, {
+    method: 'POST',
+    body: JSON.stringify({ ...payload, manageToken }),
+    headers: guestToken ? { Authorization: `Bearer ${guestToken}` } : undefined,
+  });
+
+  return {
+    ...response,
+    event: mapEvent(response.event),
+  };
+};
+
+export const refreshAdminToken = (token: string) =>
+  request<{ token: string }>('/api/admin/token', {
+    method: 'POST',
+    token,
+  });

--- a/lib/session.ts
+++ b/lib/session.ts
@@ -1,0 +1,55 @@
+const GUEST_TOKEN_PREFIX = 'party-inviter-guest-token-';
+const MANAGE_TOKEN_PREFIX = 'party-inviter-manage-token-';
+
+const safeSessionStorage = () => {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+  try {
+    return window.sessionStorage;
+  } catch (error) {
+    console.error('Unable to access sessionStorage:', error);
+    return null;
+  }
+};
+
+export const storeGuestToken = (eventId: string, token: string) => {
+  const storage = safeSessionStorage();
+  if (!storage) {
+    return;
+  }
+  storage.setItem(`${GUEST_TOKEN_PREFIX}${eventId}`, token);
+};
+
+export const readGuestToken = (eventId: string) => {
+  const storage = safeSessionStorage();
+  if (!storage) {
+    return null;
+  }
+  return storage.getItem(`${GUEST_TOKEN_PREFIX}${eventId}`);
+};
+
+export const clearGuestToken = (eventId: string) => {
+  const storage = safeSessionStorage();
+  if (!storage) {
+    return;
+  }
+  storage.removeItem(`${GUEST_TOKEN_PREFIX}${eventId}`);
+  storage.removeItem(`${MANAGE_TOKEN_PREFIX}${eventId}`);
+};
+
+export const storeManageToken = (eventId: string, token: string) => {
+  const storage = safeSessionStorage();
+  if (!storage) {
+    return;
+  }
+  storage.setItem(`${MANAGE_TOKEN_PREFIX}${eventId}`, token);
+};
+
+export const readManageToken = (eventId: string) => {
+  const storage = safeSessionStorage();
+  if (!storage) {
+    return null;
+  }
+  return storage.getItem(`${MANAGE_TOKEN_PREFIX}${eventId}`);
+};

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "server": "node server/index.js"
   },
   "dependencies": {
     "react": "^19.1.1",

--- a/server/auth.js
+++ b/server/auth.js
@@ -1,0 +1,34 @@
+import jwt from 'jsonwebtoken';
+
+const ADMIN_JWT_SECRET = process.env.ADMIN_JWT_SECRET || 'super-secret-admin';
+const GUEST_JWT_SECRET = process.env.GUEST_JWT_SECRET || 'super-secret-guest';
+
+export const signAdminToken = () =>
+  jwt.sign(
+    {
+      role: 'admin',
+    },
+    ADMIN_JWT_SECRET,
+    { expiresIn: process.env.ADMIN_TOKEN_TTL || '12h' },
+  );
+
+export const verifyAdminToken = (token) => jwt.verify(token, ADMIN_JWT_SECRET);
+
+export const signGuestToken = (eventId) =>
+  jwt.sign(
+    {
+      role: 'guest',
+      eventId,
+    },
+    GUEST_JWT_SECRET,
+    { expiresIn: process.env.GUEST_TOKEN_TTL || '7d' },
+  );
+
+export const verifyGuestToken = (token) => jwt.verify(token, GUEST_JWT_SECRET);
+
+export const extractBearerToken = (authorizationHeader = '') => {
+  if (!authorizationHeader.startsWith('Bearer ')) {
+    return null;
+  }
+  return authorizationHeader.slice('Bearer '.length).trim();
+};

--- a/server/db.js
+++ b/server/db.js
@@ -1,0 +1,109 @@
+import mysql from 'mysql2/promise';
+import bcrypt from 'bcryptjs';
+import crypto from 'crypto';
+
+const parseDatabaseUrl = (url) => {
+  const { hostname, username, password, pathname, port } = new URL(url);
+  const dbName = pathname.replace(/^\//, '');
+  return {
+    host: hostname,
+    user: username,
+    password,
+    database: dbName,
+    port: port ? Number.parseInt(port, 10) : 3306,
+  };
+};
+
+const createPool = () => {
+  const url = process.env.DATABASE_URL;
+  const config = url ? parseDatabaseUrl(url) : {
+    host: process.env.DB_HOST || 'localhost',
+    user: process.env.DB_USER || 'root',
+    password: process.env.DB_PASSWORD || '',
+    database: process.env.DB_NAME || 'party_inviter',
+    port: process.env.DB_PORT ? Number.parseInt(process.env.DB_PORT, 10) : 3306,
+  };
+
+  return mysql.createPool({
+    ...config,
+    waitForConnections: true,
+    connectionLimit: Number.parseInt(process.env.DB_CONNECTION_LIMIT || '10', 10),
+    ssl: process.env.DB_SSL === 'true' ? { rejectUnauthorized: false } : undefined,
+  });
+};
+
+export const pool = createPool();
+
+export const query = (sql, params = []) => pool.query(sql, params);
+export const getConnection = () => pool.getConnection();
+
+const EVENT_TABLE_SQL = `
+CREATE TABLE IF NOT EXISTS events (
+  id VARCHAR(36) PRIMARY KEY,
+  title VARCHAR(255) NOT NULL,
+  host VARCHAR(255) NOT NULL,
+  start_date DATETIME NOT NULL,
+  end_date DATETIME NULL,
+  location VARCHAR(255) NOT NULL,
+  message TEXT,
+  show_guest_list TINYINT(1) DEFAULT 1,
+  password_hash VARCHAR(255) NULL,
+  allow_share_link TINYINT(1) DEFAULT 1,
+  theme JSON NULL,
+  background_image LONGTEXT NULL,
+  hero_images JSON NULL,
+  share_token VARCHAR(64) NOT NULL UNIQUE,
+  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+`;
+
+const GUEST_TABLE_SQL = `
+CREATE TABLE IF NOT EXISTS guests (
+  id VARCHAR(36) PRIMARY KEY,
+  event_id VARCHAR(36) NOT NULL,
+  name VARCHAR(255) NOT NULL,
+  plus_ones INT NOT NULL DEFAULT 0,
+  comment TEXT,
+  email VARCHAR(255),
+  status ENUM('attending', 'not-attending') NOT NULL,
+  responded_at DATETIME NOT NULL,
+  manage_token VARCHAR(64) UNIQUE,
+  UNIQUE KEY unique_guest_email (event_id, email),
+  FOREIGN KEY (event_id) REFERENCES events(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+`;
+
+export const initializeDatabase = async () => {
+  await query(EVENT_TABLE_SQL);
+  await query(GUEST_TABLE_SQL);
+};
+
+export const generateId = () => crypto.randomUUID();
+export const generateShareToken = () => crypto.randomBytes(9).toString('hex');
+export const generateManageToken = () => crypto.randomBytes(12).toString('hex');
+
+export const hashPassword = async (password) => {
+  const rounds = Number.parseInt(process.env.BCRYPT_ROUNDS || '10', 10);
+  return bcrypt.hash(password, rounds);
+};
+
+export const verifyPassword = (password, hash) => bcrypt.compare(password, hash);
+
+export const mapEventRow = (row, guests = []) => ({
+  id: row.id,
+  title: row.title,
+  host: row.host,
+  date: row.start_date.toISOString(),
+  endDate: row.end_date ? row.end_date.toISOString() : undefined,
+  location: row.location,
+  message: row.message || '',
+  showGuestList: row.show_guest_list === 1,
+  passwordProtected: Boolean(row.password_hash),
+  allowShareLink: row.allow_share_link === 1,
+  theme: row.theme ? JSON.parse(row.theme) : undefined,
+  backgroundImage: row.background_image || undefined,
+  heroImages: row.hero_images ? JSON.parse(row.hero_images) : undefined,
+  shareToken: row.share_token,
+  guests,
+});

--- a/server/email.js
+++ b/server/email.js
@@ -1,0 +1,88 @@
+import nodemailer from 'nodemailer';
+
+const MAIL_TO = process.env.MAIL_TO;
+
+const mailgunConfigured = () => process.env.MAILGUN_API_KEY && process.env.MAILGUN_DOMAIN;
+
+const sendViaMailgun = async ({ subject, text, html }) => {
+  const apiKey = process.env.MAILGUN_API_KEY;
+  const domain = process.env.MAILGUN_DOMAIN;
+  const from = process.env.MAIL_FROM || `Party Inviter <mailgun@${domain}>`;
+
+  const response = await fetch(`https://api.mailgun.net/v3/${domain}/messages`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Basic ${Buffer.from(`api:${apiKey}`).toString('base64')}`,
+    },
+    body: new URLSearchParams({
+      from,
+      to: MAIL_TO,
+      subject,
+      text,
+      html,
+    }),
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Mailgun request failed: ${response.status} ${body}`);
+  }
+};
+
+let smtpTransport;
+
+const getSmtpTransport = () => {
+  if (smtpTransport) {
+    return smtpTransport;
+  }
+
+  if (!process.env.SMTP_HOST) {
+    return null;
+  }
+
+  smtpTransport = nodemailer.createTransport({
+    host: process.env.SMTP_HOST,
+    port: process.env.SMTP_PORT ? Number.parseInt(process.env.SMTP_PORT, 10) : 587,
+    secure: process.env.SMTP_SECURE === 'true',
+    auth:
+      process.env.SMTP_USER && process.env.SMTP_PASSWORD
+        ? {
+            user: process.env.SMTP_USER,
+            pass: process.env.SMTP_PASSWORD,
+          }
+        : undefined,
+  });
+
+  return smtpTransport;
+};
+
+const sendViaSmtp = async ({ subject, text, html }) => {
+  const transport = getSmtpTransport();
+  if (!transport) {
+    throw new Error('SMTP transport is not configured.');
+  }
+
+  await transport.sendMail({
+    from: process.env.MAIL_FROM || 'party-inviter@localhost',
+    to: MAIL_TO,
+    subject,
+    text,
+    html,
+  });
+};
+
+export const sendNotificationEmail = async ({ subject, text, html }) => {
+  if (!MAIL_TO) {
+    return;
+  }
+
+  try {
+    if (mailgunConfigured()) {
+      await sendViaMailgun({ subject, text, html });
+    } else {
+      await sendViaSmtp({ subject, text, html });
+    }
+  } catch (error) {
+    console.error('Unable to send notification email:', error);
+  }
+};

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,468 @@
+import express from 'express';
+import cors from 'cors';
+import dotenv from 'dotenv';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import {
+  initializeDatabase,
+  query,
+  mapEventRow,
+  generateId,
+  generateShareToken,
+  hashPassword,
+  verifyPassword,
+  generateManageToken,
+  getConnection,
+} from './db.js';
+import { sendNotificationEmail } from './email.js';
+import {
+  signAdminToken,
+  verifyAdminToken,
+  signGuestToken,
+  verifyGuestToken,
+  extractBearerToken,
+} from './auth.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+dotenv.config({ path: path.resolve(__dirname, '..', '.env') });
+dotenv.config();
+
+const app = express();
+const port = Number.parseInt(process.env.PORT || '4000', 10);
+
+app.use(cors({
+  origin: process.env.CORS_ORIGIN ? process.env.CORS_ORIGIN.split(',') : true,
+  credentials: true,
+}));
+app.use(express.json({ limit: '5mb' }));
+
+const mapGuestRow = row => ({
+  id: row.id,
+  name: row.name,
+  plusOnes: row.plus_ones,
+  comment: row.comment || '',
+  email: row.email || undefined,
+  status: row.status,
+  respondedAt: row.responded_at ? row.responded_at.toISOString() : undefined,
+  manageToken: row.manage_token || undefined,
+});
+
+const getEventGuests = async eventId => {
+  const [rows] = await query('SELECT * FROM guests WHERE event_id = ? ORDER BY responded_at DESC', [eventId]);
+  return rows.map(mapGuestRow);
+};
+
+const getEventById = async eventId => {
+  const [rows] = await query('SELECT * FROM events WHERE id = ?', [eventId]);
+  const row = rows[0];
+  if (!row) {
+    return null;
+  }
+  const guests = await getEventGuests(row.id);
+  return mapEventRow(row, guests);
+};
+
+const getEventByShareToken = async shareToken => {
+  const [rows] = await query('SELECT * FROM events WHERE share_token = ?', [shareToken]);
+  return rows[0] || null;
+};
+
+const sanitizeGuestsForPublic = (eventRow, guests) => {
+  if (eventRow.show_guest_list !== 1) {
+    return [];
+  }
+  return guests.map(({ manageToken, ...guest }) => guest);
+};
+
+const authenticateAdmin = (req, res, next) => {
+  const token = extractBearerToken(req.headers.authorization || '');
+  if (!token) {
+    return res.status(401).json({ message: 'Admin authorization required.' });
+  }
+
+  try {
+    verifyAdminToken(token);
+    return next();
+  } catch (error) {
+    console.error('Invalid admin token:', error);
+    return res.status(401).json({ message: 'Invalid admin token.' });
+  }
+};
+
+const requireGuestAuthorization = (eventRow, req, res) => {
+  if (!eventRow.password_hash) {
+    return { authorized: true, guestToken: null };
+  }
+
+  const token = extractBearerToken(req.headers.authorization || '');
+  if (!token) {
+    return { authorized: false, guestToken: null };
+  }
+
+  try {
+    const payload = verifyGuestToken(token);
+    if (payload.eventId !== eventRow.id) {
+      return { authorized: false, guestToken: null };
+    }
+    return { authorized: true, guestToken: token };
+  } catch (error) {
+    console.error('Invalid guest token:', error);
+    return { authorized: false, guestToken: null };
+  }
+};
+
+app.get('/health', (_req, res) => {
+  res.json({ status: 'ok' });
+});
+
+app.post('/api/access', async (req, res) => {
+  const { password } = req.body || {};
+  if (!password) {
+    return res.status(400).json({ message: 'Password is required.' });
+  }
+
+  const adminSecret = process.env.ADMIN_PASSWORD;
+  const adminHash = process.env.ADMIN_PASSWORD_HASH;
+
+  try {
+    let adminValid = false;
+    if (adminHash) {
+      adminValid = await verifyPassword(password, adminHash);
+    } else if (adminSecret) {
+      adminValid = password === adminSecret;
+    }
+
+    if (adminValid) {
+      const token = signAdminToken();
+      return res.json({ type: 'admin', token });
+    }
+
+    const [eventRows] = await query('SELECT * FROM events WHERE password_hash IS NOT NULL');
+    for (const row of eventRows) {
+      const matches = await verifyPassword(password, row.password_hash);
+      if (matches) {
+        const guestToken = signGuestToken(row.id);
+        return res.json({ type: 'event', eventId: row.id, shareToken: row.share_token, guestToken });
+      }
+    }
+
+    return res.status(401).json({ message: 'No event or admin area matched that password. Please try again.' });
+  } catch (error) {
+    console.error('Access check failed:', error);
+    return res.status(500).json({ message: 'Unable to verify password.' });
+  }
+});
+
+app.post('/api/admin/token', authenticateAdmin, (_req, res) => {
+  const token = signAdminToken();
+  res.json({ token });
+});
+
+app.get('/api/admin/events', authenticateAdmin, async (_req, res) => {
+  const [rows] = await query('SELECT * FROM events ORDER BY created_at DESC');
+  const events = await Promise.all(
+    rows.map(async row => {
+      const guests = await getEventGuests(row.id);
+      return mapEventRow(row, guests);
+    }),
+  );
+  res.json(events);
+});
+
+app.post('/api/admin/events', authenticateAdmin, async (req, res) => {
+  const {
+    title,
+    host,
+    date,
+    endDate,
+    location,
+    message,
+    showGuestList,
+    allowShareLink,
+    password,
+    theme,
+    backgroundImage,
+    heroImages,
+  } = req.body || {};
+
+  if (!title || !host || !date || !location) {
+    return res.status(400).json({ message: 'Missing required fields.' });
+  }
+
+  const id = generateId();
+  const shareToken = generateShareToken();
+  const startDate = new Date(date);
+  const endDateValue = endDate ? new Date(endDate) : null;
+
+  try {
+    const passwordHash = password ? await hashPassword(password) : null;
+    await query(
+      `INSERT INTO events (id, title, host, start_date, end_date, location, message, show_guest_list, password_hash, allow_share_link, theme, background_image, hero_images, share_token)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      [
+        id,
+        title,
+        host,
+        startDate,
+        endDateValue,
+        location,
+        message || '',
+        showGuestList ? 1 : 0,
+        passwordHash,
+        allowShareLink ? 1 : 0,
+        theme ? JSON.stringify(theme) : null,
+        backgroundImage || null,
+        heroImages ? JSON.stringify(heroImages) : null,
+        shareToken,
+      ],
+    );
+
+    const event = await getEventById(id);
+    return res.status(201).json(event);
+  } catch (error) {
+    console.error('Unable to create event:', error);
+    return res.status(500).json({ message: 'Unable to create event.' });
+  }
+});
+
+app.put('/api/admin/events/:eventId', authenticateAdmin, async (req, res) => {
+  const { eventId } = req.params;
+  const [existingRows] = await query('SELECT * FROM events WHERE id = ?', [eventId]);
+  const existingRow = existingRows[0];
+  if (!existingRow) {
+    return res.status(404).json({ message: 'Event not found.' });
+  }
+
+  const {
+    title,
+    host,
+    date,
+    endDate,
+    location,
+    message,
+    showGuestList,
+    allowShareLink,
+    password,
+    removePassword,
+    theme,
+    backgroundImage,
+    heroImages,
+  } = req.body || {};
+
+  if (!title || !host || !date || !location) {
+    return res.status(400).json({ message: 'Missing required fields.' });
+  }
+
+  try {
+    let passwordHash = existingRow.password_hash;
+    if (removePassword) {
+      passwordHash = null;
+    } else if (password) {
+      passwordHash = await hashPassword(password);
+    }
+
+    await query(
+      `UPDATE events SET
+        title = ?,
+        host = ?,
+        start_date = ?,
+        end_date = ?,
+        location = ?,
+        message = ?,
+        show_guest_list = ?,
+        password_hash = ?,
+        allow_share_link = ?,
+        theme = ?,
+        background_image = ?,
+        hero_images = ?
+      WHERE id = ?`,
+      [
+        title,
+        host,
+        new Date(date),
+        endDate ? new Date(endDate) : null,
+        location,
+        message || '',
+        showGuestList ? 1 : 0,
+        passwordHash,
+        allowShareLink ? 1 : 0,
+        theme ? JSON.stringify(theme) : null,
+        backgroundImage || null,
+        heroImages ? JSON.stringify(heroImages) : null,
+        eventId,
+      ],
+    );
+
+    const updated = await getEventById(eventId);
+    return res.json(updated);
+  } catch (error) {
+    console.error('Unable to update event:', error);
+    return res.status(500).json({ message: 'Unable to update event.' });
+  }
+});
+
+app.delete('/api/admin/events/:eventId', authenticateAdmin, async (req, res) => {
+  const { eventId } = req.params;
+  await query('DELETE FROM events WHERE id = ?', [eventId]);
+  res.status(204).end();
+});
+
+app.get('/api/public/events/:shareToken', async (req, res) => {
+  const { shareToken } = req.params;
+  const eventRow = await getEventByShareToken(shareToken);
+  if (!eventRow) {
+    return res.status(404).json({ message: 'Event not found.' });
+  }
+
+  const { authorized, guestToken } = requireGuestAuthorization(eventRow, req, res);
+  if (eventRow.password_hash && !authorized) {
+    return res.status(401).json({ requiresPassword: true });
+  }
+
+  const guests = await getEventGuests(eventRow.id);
+  const event = mapEventRow(eventRow, sanitizeGuestsForPublic(eventRow, guests));
+  return res.json({ event, guestToken: guestToken || undefined });
+});
+
+app.post('/api/public/events/:shareToken/access', async (req, res) => {
+  const { shareToken } = req.params;
+  const { password } = req.body || {};
+  if (!password) {
+    return res.status(400).json({ message: 'Password is required.' });
+  }
+
+  const eventRow = await getEventByShareToken(shareToken);
+  if (!eventRow) {
+    return res.status(404).json({ message: 'Event not found.' });
+  }
+
+  if (!eventRow.password_hash) {
+    const guestToken = signGuestToken(eventRow.id);
+    return res.json({ guestToken, eventId: eventRow.id });
+  }
+
+  const matches = await verifyPassword(password, eventRow.password_hash);
+  if (!matches) {
+    return res.status(401).json({ message: 'Incorrect password.' });
+  }
+
+  const guestToken = signGuestToken(eventRow.id);
+  return res.json({ guestToken, eventId: eventRow.id });
+});
+
+app.post('/api/public/events/:shareToken/rsvps', async (req, res) => {
+  const { shareToken } = req.params;
+  const { name, plusOnes = 0, comment, email, status, manageToken } = req.body || {};
+
+  if (!name || !status || !['attending', 'not-attending'].includes(status)) {
+    return res.status(400).json({ message: 'Name and valid status are required.' });
+  }
+
+  const eventRow = await getEventByShareToken(shareToken);
+  if (!eventRow) {
+    return res.status(404).json({ message: 'Event not found.' });
+  }
+
+  const { authorized } = requireGuestAuthorization(eventRow, req, res);
+  if (eventRow.password_hash && !authorized) {
+    return res.status(401).json({ message: 'Password required to submit RSVP.' });
+  }
+
+  const connection = await getConnection();
+  const now = new Date();
+  try {
+    await connection.beginTransaction();
+
+    let guestRow;
+    if (manageToken) {
+      const [rows] = await connection.query('SELECT * FROM guests WHERE manage_token = ? AND event_id = ?', [manageToken, eventRow.id]);
+      guestRow = rows[0];
+    }
+
+    if (!guestRow && email) {
+      const [rows] = await connection.query('SELECT * FROM guests WHERE event_id = ? AND email = ?', [eventRow.id, email]);
+      guestRow = rows[0];
+    }
+
+    if (guestRow) {
+      await connection.query(
+        `UPDATE guests SET name = ?, plus_ones = ?, comment = ?, email = ?, status = ?, responded_at = ?, manage_token = ? WHERE id = ?`,
+        [
+          name,
+          Number.parseInt(plusOnes, 10) || 0,
+          comment || '',
+          email || null,
+          status,
+          now,
+          guestRow.manage_token,
+          guestRow.id,
+        ],
+      );
+    } else {
+      const newGuestId = generateId();
+      const newManageToken = manageToken || generateManageToken();
+      await connection.query(
+        `INSERT INTO guests (id, event_id, name, plus_ones, comment, email, status, responded_at, manage_token)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        [
+          newGuestId,
+          eventRow.id,
+          name,
+          Number.parseInt(plusOnes, 10) || 0,
+          comment || '',
+          email || null,
+          status,
+          now,
+          newManageToken,
+        ],
+      );
+      const [rows] = await connection.query('SELECT * FROM guests WHERE id = ?', [newGuestId]);
+      guestRow = rows[0];
+    }
+
+    await connection.commit();
+
+    const guests = await getEventGuests(eventRow.id);
+    const event = mapEventRow(eventRow, sanitizeGuestsForPublic(eventRow, guests));
+    const guest = mapGuestRow(guestRow);
+
+    const subject = `RSVP update for ${eventRow.title}`;
+    const emailText = `${guest.name} is ${guest.status === 'attending' ? 'attending' : 'not attending'}${
+      guest.plusOnes > 0 ? ` with +${guest.plusOnes}` : ''
+    }`;
+    await sendNotificationEmail({
+      subject,
+      text: `${emailText}\nEvent: ${eventRow.title}\nComment: ${guest.comment || '—'}`,
+      html: `<p>${emailText}</p><p><strong>Event:</strong> ${eventRow.title}</p><p><strong>Comment:</strong> ${guest.comment || '—'}</p>`,
+    });
+
+    res.json({
+      event,
+      guest,
+      guestToken: eventRow.password_hash ? signGuestToken(eventRow.id) : undefined,
+      manageToken: guest.manageToken,
+    });
+  } catch (error) {
+    await connection.rollback();
+    console.error('Unable to process RSVP:', error);
+    res.status(500).json({ message: 'Unable to submit RSVP.' });
+  } finally {
+    connection.release();
+  }
+});
+
+const start = async () => {
+  try {
+    await initializeDatabase();
+    app.listen(port, () => {
+      console.log(`Party Inviter server listening on port ${port}`);
+    });
+  } catch (error) {
+    console.error('Failed to start server:', error);
+    process.exit(1);
+  }
+};
+
+start();

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,0 +1,1130 @@
+{
+  "name": "party-inviter-server",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "party-inviter-server",
+      "version": "1.0.0",
+      "dependencies": {
+        "bcryptjs": "^2.4.3",
+        "cors": "^2.8.5",
+        "dotenv": "^16.4.7",
+        "express": "^4.21.2",
+        "jsonwebtoken": "^9.0.2",
+        "mysql2": "^3.11.3",
+        "nodemailer": "^6.9.15"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
+    "node_modules/aws-ssl-profiles": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/aws-ssl-profiles/-/aws-ssl-profiles-1.1.2.tgz",
+      "integrity": "sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/bcryptjs": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
+      "integrity": "sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ==",
+      "license": "MIT"
+    },
+    "node_modules/body-parser": {
+      "version": "1.20.3",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
+      "integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "on-finished": "2.4.1",
+        "qs": "6.13.0",
+        "raw-body": "2.5.2",
+        "type-is": "~1.6.18",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
+      "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "license": "MIT"
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/denque": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express": {
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
+      "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.20.3",
+        "content-disposition": "0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "0.7.1",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "1.3.1",
+        "fresh": "0.5.2",
+        "http-errors": "2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "6.13.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "0.19.0",
+        "serve-static": "1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
+      "integrity": "sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "2.0.1",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/generate-function": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
+      "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-property": "^1.0.2"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "2.0.0",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-property": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==",
+      "license": "MIT"
+    },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
+      "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jsonwebtoken/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/jwa": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.2.tgz",
+      "integrity": "sha512-eeH5JO+21J78qMvTIDdBXidBd6nG2kZjg5Ohz/1fpa28Z4CcsWUzJ1ZZyFq/3z3N17aZy+ZuBoHljASbL1WfOw==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+      "license": "MIT"
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/lru.min": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/lru.min/-/lru.min-1.1.2.tgz",
+      "integrity": "sha512-Nv9KddBcQSlQopmBHXSsZVY5xsdlZkdH/Iey0BlcBYggMd4two7cZnKOK9vmy3nY0O5RGH99z1PCeTpPqszUYg==",
+      "license": "MIT",
+      "engines": {
+        "bun": ">=1.0.0",
+        "deno": ">=1.30.0",
+        "node": ">=8.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wellwelwel"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/mysql2": {
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.15.0.tgz",
+      "integrity": "sha512-tT6pomf5Z/I7Jzxu8sScgrYBMK9bUFWd7Kbo6Fs1L0M13OOIJ/ZobGKS3Z7tQ8Re4lj+LnLXIQVZZxa3fhYKzA==",
+      "license": "MIT",
+      "dependencies": {
+        "aws-ssl-profiles": "^1.1.1",
+        "denque": "^2.1.0",
+        "generate-function": "^2.3.1",
+        "iconv-lite": "^0.7.0",
+        "long": "^5.2.1",
+        "lru.min": "^1.0.0",
+        "named-placeholders": "^1.1.3",
+        "seq-queue": "^0.0.5",
+        "sqlstring": "^2.3.2"
+      },
+      "engines": {
+        "node": ">= 8.0"
+      }
+    },
+    "node_modules/mysql2/node_modules/iconv-lite": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.0.tgz",
+      "integrity": "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/named-placeholders": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/named-placeholders/-/named-placeholders-1.1.3.tgz",
+      "integrity": "sha512-eLoBxg6wE/rZkJPhU/xRX1WTpkFEwDJEN96oxFrTsqBdbT5ec295Q+CoHrL9IT0DipqKhmGcaZmwOt8OON5x1w==",
+      "license": "MIT",
+      "dependencies": {
+        "lru-cache": "^7.14.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/nodemailer": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.10.1.tgz",
+      "integrity": "sha512-Z+iLaBGVaSjbIzQ4pX6XV41HrooLsQ10ZWPUehGmuantvzWoDVBnmsdUcOIDM1t+yPor5pDhVlDESgOMEGxhHA==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
+      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+      "license": "MIT"
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
+      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.0.6"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
+      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/send": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.0.tgz",
+      "integrity": "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "2.0.0",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/seq-queue": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/seq-queue/-/seq-queue-0.0.5.tgz",
+      "integrity": "sha512-hr3Wtp/GZIc/6DAGPDcV4/9WoZhjrkXsi5B/07QgX8tsdc6ilr7BFM6PM6rbdAX1kFSDYeZGLipIZZKyQP0O5Q=="
+    },
+    "node_modules/serve-static": {
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
+      "integrity": "sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "0.19.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/sqlstring": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/sqlstring/-/sqlstring-2.3.3.tgz",
+      "integrity": "sha512-qC9iz2FlN7DQl3+wjwn3802RTyjCx7sDvfQEXchwa6CWOx07/WVfh91gBmQ9fahw8snwGEWU3xGzOt4tFyHLxg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    }
+  }
+}

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "party-inviter-server",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js",
+    "dev": "NODE_ENV=development node index.js"
+  },
+  "dependencies": {
+    "bcryptjs": "^2.4.3",
+    "cors": "^2.8.5",
+    "dotenv": "^16.4.7",
+    "express": "^4.21.2",
+    "jsonwebtoken": "^9.0.2",
+    "mysql2": "^3.11.3",
+    "nodemailer": "^6.9.15"
+  }
+}

--- a/types.ts
+++ b/types.ts
@@ -6,6 +6,7 @@ export interface Guest {
   email?: string;
   status: 'attending' | 'not-attending';
   respondedAt?: string;
+  manageToken?: string;
 }
 
 export interface EventTheme {
@@ -32,10 +33,10 @@ export interface Event {
   message: string;
   showGuestList: boolean;
   guests: Guest[];
-  password?: string;
+  passwordProtected: boolean;
   theme?: EventTheme;
   backgroundImage?: string;
   heroImages?: string[];
-  allowShareLink?: boolean;
-  shareToken?: string;
+  allowShareLink: boolean;
+  shareToken: string;
 }


### PR DESCRIPTION
## Summary
- replace local storage state with an API client and admin context so events persist across sessions and admin routes require authentication
- add a MySQL-backed Express API that manages events/RSVPs, issues JWTs for admins and guests, and can send email notifications on new activity
- document the new deployment requirements and provide a sample `.env` for configuring the database, auth secrets, and mail settings

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ce1a049c24832d8c962be3edd41d9b